### PR TITLE
Changes to how screen position and size is restored from config

### DIFF
--- a/src/Asv.Drones.Gui/MainWindow.axaml.cs
+++ b/src/Asv.Drones.Gui/MainWindow.axaml.cs
@@ -155,9 +155,38 @@ namespace Asv.Drones.Gui
             {
                 var shellViewConfig = _configuration.Get<ShellViewConfig>(nameof(ShellViewConfig));
 
-                Height = shellViewConfig.Height;
-                Width = shellViewConfig.Width;
-                Position = new PixelPoint(shellViewConfig.PositionX, shellViewConfig.PositionY);
+                var totalWidth = 0;
+                var totalHeight = 0;
+
+                foreach (var scr in Screens.All)
+                {
+                    totalWidth += scr.Bounds.Width;
+                    totalHeight += scr.Bounds.Height;
+                }
+
+                if (shellViewConfig.PositionX > totalWidth || shellViewConfig.PositionY > totalHeight)
+                {
+                    Position = new PixelPoint(0, 0);
+                }
+                else
+                {
+                    Position = new PixelPoint(shellViewConfig.PositionX, shellViewConfig.PositionY);
+                }
+
+                if (shellViewConfig.Height > totalHeight || shellViewConfig.Width > totalWidth)
+                {
+                    var scrBounds = Screens.Primary.Bounds;
+                    
+                    Height = scrBounds.Height * 0.9;
+                    Width = scrBounds.Width * 0.9;
+                    
+                    Position = new PixelPoint(0, 0);
+                }
+                else
+                {
+                    Height = shellViewConfig.Height;
+                    Width = shellViewConfig.Width;
+                }
             }
         }
 


### PR DESCRIPTION
If window position is out of bounds, it will be set to top left corner of main screen. If window is bigger than all screens, it will be set to be 90% of the main screen and it's position set to be in top left corner of primary screen.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204337701409792