### PR TITLE
Widget size is now correctly restored from config

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Flight/FlightPageView.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Flight/FlightPageView.cs
@@ -4,11 +4,6 @@ using Avalonia.Controls;
 
 namespace Asv.Drones.Gui.Core
 {
-    public class FlightPageViewConfig
-    {
-        public string Columns { get; set; }
-    }
-    
     [ExportView(typeof(FlightPageViewModel))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class FlightPageView:MapPageView
@@ -27,11 +22,11 @@ namespace Asv.Drones.Gui.Core
         {
             base.OnLoaded();
 
-            if (_configuration.Exist<FlightPageViewConfig>(nameof(FlightPageViewConfig)))
+            if (_configuration.Exist<MapPageViewConfig>(nameof(FlightPageView)))
             {
-                var columns = _configuration.Get<FlightPageViewConfig>(nameof(FlightPageViewConfig));
+                var mapPageViewConfig = _configuration.Get<MapPageViewConfig>(nameof(FlightPageView));
                 
-                SetColumnDefinitions(((Grid)this.Content).ColumnDefinitions, columns.Columns);
+                SetColumnAndRowDefinitions((Grid)Content, mapPageViewConfig);
             }
         }
 
@@ -39,12 +34,13 @@ namespace Asv.Drones.Gui.Core
         {
             base.OnUnloaded();
 
-            var flightPageViewConfig = new FlightPageViewConfig
+            var mapPageViewConfig = new MapPageViewConfig
             {
-                Columns = ((Grid)this.Content).ColumnDefinitions.ToString()
+                Columns = ((Grid)this.Content).ColumnDefinitions.ToString(),
+                Rows = ((Grid)this.Content).RowDefinitions.ToString()
             };
 
-            _configuration.Set(nameof(FlightPageViewConfig), flightPageViewConfig);
+            _configuration.Set(nameof(FlightPageView), mapPageViewConfig);
         }
     }
 }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageView.axaml.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageView.axaml.cs
@@ -1,11 +1,16 @@
 using System.Text.RegularExpressions;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 namespace Asv.Drones.Gui.Core
 {
+    public class MapPageViewConfig
+    {
+        public string Columns { get; set; }
+        public string Rows { get; set; }
+    }
+    
     public partial class MapPageView : ReactiveUserControl<MapPageViewModel>
     {
         public MapPageView()
@@ -18,25 +23,43 @@ namespace Asv.Drones.Gui.Core
             AvaloniaXamlLoader.Load(this);
         }
 
-        protected static void SetColumnDefinitions(ColumnDefinitions columnDefinitions, string values)
+        protected static void SetColumnAndRowDefinitions(Grid grid, MapPageViewConfig cfg)
         {
-            var parsedValues = Regex.Split(values, ",");
+            var parsedColumnValues = Regex.Split(cfg.Columns, ",");
+            var parsedRowValues = Regex.Split(cfg.Rows, ",");
 
-            columnDefinitions.Clear();
+            grid.ColumnDefinitions.Clear();
+            grid.RowDefinitions.Clear();
             
-            foreach (var value in parsedValues)
+            foreach (var value in parsedColumnValues)
             {
                 if (value.Contains('*'))
                 {
-                    int.TryParse(value.AsSpan(0, (value.Length - 1)), out var gridLengthValue);
+                    int.TryParse(value.Substring(0, value.Length - 1).Split('.').FirstOrDefault(), out var gridLengthValue);
                     
-                    columnDefinitions.Add(new ColumnDefinition(new GridLength(gridLengthValue, GridUnitType.Star)));
+                    grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(gridLengthValue, GridUnitType.Star)));
                 }
                 else
                 {
-                    int.TryParse(value, out var gridLengthValue);
+                    int.TryParse(value.Split('.').FirstOrDefault(), out var gridLengthValue);
                     
-                    columnDefinitions.Add(new ColumnDefinition(new GridLength(gridLengthValue)));
+                    grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(gridLengthValue)));
+                }
+            }
+            
+            foreach (var value in parsedRowValues)
+            {
+                if (value.Contains('*'))
+                {
+                    int.TryParse(value.Substring(0, value.Length - 1).Split('.').FirstOrDefault(), out var gridLengthValue);
+                    
+                    grid.RowDefinitions.Add(new RowDefinition(new GridLength(gridLengthValue, GridUnitType.Star)));
+                }
+                else
+                {
+                    int.TryParse(value.Split('.').FirstOrDefault(), out var gridLengthValue);
+                    
+                    grid.RowDefinitions.Add(new RowDefinition(new GridLength(gridLengthValue)));
                 }
             }
         }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningPageView.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningPageView.cs
@@ -4,11 +4,6 @@ using Avalonia.Controls;
 
 namespace Asv.Drones.Gui.Core
 {
-    public class PlaningPageViewConfig
-    {
-        public string Columns { get; set; }
-    }
-    
     [ExportView(typeof(PlaningPageViewModel))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class PlaningPageView:MapPageView
@@ -28,11 +23,11 @@ namespace Asv.Drones.Gui.Core
         {
             base.OnLoaded();
 
-            if (_configuration.Exist<PlaningPageViewConfig>(nameof(PlaningPageViewConfig)))
+            if (_configuration.Exist<MapPageViewConfig>(nameof(PlaningPageView)))
             {
-                var columns = _configuration.Get<PlaningPageViewConfig>(nameof(PlaningPageViewConfig));
+                var mapPageViewConfig = _configuration.Get<MapPageViewConfig>(nameof(PlaningPageView));
                 
-                SetColumnDefinitions(((Grid)this.Content).ColumnDefinitions, columns.Columns);
+                SetColumnAndRowDefinitions((Grid)Content, mapPageViewConfig);
             }
         }
 
@@ -40,12 +35,13 @@ namespace Asv.Drones.Gui.Core
         {
             base.OnUnloaded();
 
-            var flightPageViewConfig = new PlaningPageViewConfig
+            var mapPageViewConfig = new MapPageViewConfig
             {
-                Columns = ((Grid)this.Content).ColumnDefinitions.ToString()
+                Columns = ((Grid)this.Content).ColumnDefinitions.ToString(),
+                Rows = ((Grid)this.Content).RowDefinitions.ToString()
             };
 
-            _configuration.Set(nameof(PlaningPageViewConfig), flightPageViewConfig);
+            _configuration.Set(nameof(PlaningPageView), mapPageViewConfig);
         }
     }
 }


### PR DESCRIPTION
Error occured if column definitions contained fractional numbers. In this case TryParse returns 0 and Grid columns become essentially invisible.

Fractional numbers were generated because of Windows global zoom settings. If they are different from 100%, then pixel size can become fractional.

To resolve the issue we take the restored value and drop it's fractional part before parsing.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204337701409804