### PR TITLE
fix(core): enable connections by default on creation or edit

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/SerialPortViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/SerialPortViewModel.cs
@@ -75,7 +75,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     Name = Title,
                     ConnectionString = $"serial:{SelectedPort}?br={SelectedBaudRate}",
-                    IsEnabled = false,
+                    IsEnabled = true
                 });
             }
             catch (Exception e)

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/TcpPortViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/TcpPortViewModel.cs
@@ -61,7 +61,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     Name = Title,
                     ConnectionString = $"tcp://{IpAddress}:{Port}" + (IsTcpIpServer ? "?srv=true":string.Empty),
-                    IsEnabled = false,
+                    IsEnabled = true,
                 });
                 
             }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/UdpPortViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/Dialogs/UdpPortViewModel.cs
@@ -75,7 +75,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     Name = Title,
                     ConnectionString = $"udp://{LocalIpAddress}:{LocalPort}" + (IsRemote ? $"?rhost={RemoteIpAddress}&rport={RemotePort}":string.Empty),
-                    IsEnabled = false
+                    IsEnabled = true
                 });
             }
             catch (Exception e)


### PR DESCRIPTION
Enabled the connections by default in TcpPortViewModel, SerialPortViewModel, and UdpPortViewModel on initialization by changing "IsEnabled" attribute from false to true. This simplifies the user experience by making connections active as soon as they are created instead of requiring users to manually activate them.