### PR TITLE
fix: add dotnet workload restore in ci workflows

### DIFF
--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Restore dependencies
         run: |
           cd src
+          dotnet workload restore
           dotnet restore
 
       - name: Build application

--- a/.github/workflows/ubuntu_release.yml
+++ b/.github/workflows/ubuntu_release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Restore dependencies
         run: |
           cd src
+          dotnet workload restore
           dotnet restore
 
       - name: Build application

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Restore dependencies
         run: |
           cd src
+          dotnet workload restore 
           dotnet restore
 
       - name: Build application


### PR DESCRIPTION
Added a `dotnet workload restore` command in the restore dependencies step for macOS, Ubuntu, and Windows release workflows. This is necessary to ensure the correct dotnet workload is restored before dependency restoration for better build success.

Asana: https://app.asana.com/0/1203851531040615/1204953971605260/f