### PR TITLE
fix(uav): add tooltips to grid in SelectModeView

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/SelectModeView.axaml
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/SelectModeView.axaml
@@ -26,7 +26,7 @@
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Grid>
+                    <Grid ToolTip.Tip="{CompiledBinding Mode.Description}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition SharedSizeGroup="Icon" Width="Auto"/>
                             <ColumnDefinition SharedSizeGroup="Name" Width="Auto"/>

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/SelectModeView.axaml
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/SelectModeView.axaml
@@ -15,8 +15,9 @@
         <TextBlock Text="{x:Static uav:RS.SelectModeAnchorActionView_DialogDescription}" />
         <ListBox ItemsSource="{CompiledBinding AvailableModes}" SelectedItem="{Binding SelectedMode, Mode=TwoWay}" Grid.IsSharedSizeScope="True">
             <ListBox.Styles>
-                <Style Selector="ListBoxItem">
+                <Style Selector="ListBoxItem" x:DataType="uav:VehicleModeWithIcons">
                     <Setter Property="MinHeight" Value="50" />
+                    <Setter Property="ToolTip.Tip" Value="{Binding Mode.Description}" />
                 </Style>
             </ListBox.Styles>
             <ListBox.ItemsPanel>
@@ -26,7 +27,7 @@
             </ListBox.ItemsPanel>
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Grid ToolTip.Tip="{CompiledBinding Mode.Description}">
+                    <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition SharedSizeGroup="Icon" Width="Auto"/>
                             <ColumnDefinition SharedSizeGroup="Name" Width="Auto"/>


### PR DESCRIPTION
A tooltip field has been added to the grid in SelectModeView.axaml. This change was made to provide descriptions for each mode, enhancing user understanding of each option. The tooltip is being populated with the compiled binding of each mode's description.

Asana: https://app.asana.com/0/1203851531040615/1204953971605284/f