### PR TITLE
fix(uav): update layout and title of RebootAutopilotView

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/RebootAutopilotView.axaml
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/Dialogs/RebootAutopilotView.axaml
@@ -10,26 +10,31 @@
     <Design.DataContext>
         <uav:RebootAutopilotViewModel />
     </Design.DataContext>
-    <Grid ColumnDefinitions="250, 5, 250" RowDefinitions="Auto, 5, Auto">
-        <TextBlock Text="{x:Static uav:RS.RebootAutopilotView_AutopilotReboot_Description}" 
-                   TextWrapping="Wrap" />
-        <ComboBox Grid.Column="0" Grid.Row="2" ItemsSource="{CompiledBinding AutopilotValues}"
-                  SelectedItem="{CompiledBinding SelectedAutopilotRebootShutdown}" HorizontalAlignment="Stretch">
-            <ComboBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Description}" />
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
-        <TextBlock Grid.Column="2" Grid.Row="0" Text="{x:Static uav:RS.RebootAutopilotView_CompanionReboot_Description}" 
-                   TextWrapping="Wrap" />
-        <ComboBox Grid.Column="2" Grid.Row="2" ItemsSource="{CompiledBinding CompanionValues}"
-                  SelectedItem="{CompiledBinding SelectedCompanionRebootShutdown}" HorizontalAlignment="Stretch">
-            <ComboBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Description}" />
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
-    </Grid>
+    <StackPanel Spacing="5">
+        <Grid RowDefinitions="Auto, 5, Auto">
+            <TextBlock Text="{x:Static uav:RS.RebootAutopilotView_AutopilotReboot_Description}"
+                       TextWrapping="Wrap" />
+            <ComboBox Grid.Row="2" ItemsSource="{CompiledBinding AutopilotValues}"
+                      SelectedItem="{CompiledBinding SelectedAutopilotRebootShutdown}" HorizontalAlignment="Stretch">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Description}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </Grid>
+        <Grid RowDefinitions="Auto, 5, Auto">
+            <TextBlock Grid.Row="0"
+                       Text="{x:Static uav:RS.RebootAutopilotView_CompanionReboot_Description}"
+                       TextWrapping="Wrap" />
+            <ComboBox Grid.Row="2" ItemsSource="{CompiledBinding CompanionValues}"
+                      SelectedItem="{CompiledBinding SelectedCompanionRebootShutdown}" HorizontalAlignment="Stretch">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Description}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+        </Grid>
+    </StackPanel>
 </UserControl>

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/RebootAutopilotAnchorActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/RebootAutopilotAnchorActionViewModel.cs
@@ -28,7 +28,7 @@ public class RebootAutopilotAnchorActionViewModel : UavActionActionBase
 
         var dialog = new ContentDialog()
         {
-            Title = "",
+            Title = RS.RebootAutopilotAnchorActionViewModel_Title,
             PrimaryButtonText = RS.RebootAutopilotAnchorActionViewModel_DialogPrimaryButton,
             IsSecondaryButtonEnabled = true,
             SecondaryButtonText = RS.RebootAutopilotAnchorActionViewModel_DialogSecondaryButton


### PR DESCRIPTION
Changed the ContentDialog title to use a resource string which provides better context. Replaced the Grid layout with a StackPanel in RebootAutopilotView.axaml for easier maintainability and readability. It formats the components vertically with a separation, providing a cleaner visual structure than before.

Asana: https://app.asana.com/0/1203851531040615/1204953971605291/f