### PR TITLE
fix(core): update author and app URLs in CorePlugin.cs

### DIFF
--- a/src/Asv.Drones.Gui.Core/CorePlugin.cs
+++ b/src/Asv.Drones.Gui.Core/CorePlugin.cs
@@ -65,8 +65,8 @@ public class CorePlugin: IPluginEntryPoint
         var assm = _applicationDataTemplateHost.GetType().Assembly.GetName(); // hack - to get application assembly
         var version = assm.Version?.ToString() ?? "0.0.0";
         var name = assm.Name ?? "Asv.Drones";
-        const string author = "https://github.com/asvol";
-        const string appUrl = "https://github.com/asvol/asv-drones";
+        const string author = "https://asv.me/";
+        const string appUrl = "https://docs.asv.me/";
         const string licence = "MIT License";
         var avaloniaVersion = typeof(AppBuilder).Assembly.GetName().Version?.ToString() ?? "0.0.0"; // hack to get Avalonia version
         return new AppInfo(name, version,author, appUrl, licence, avaloniaVersion);


### PR DESCRIPTION
Adjusted the author and application URLs in CorePlugin.cs to match changes in website domains. The author URL is changed from the Github profile to a personal website, and the app URL is now directing to the documentation site instead of the Github repository. This is to provide more accurate and helpful information to the users.

Asana: https://app.asana.com/0/1203851531040615/1204953971605265/f