### PR TITLE
fix(uav): add polygon styled properties to AttitudeIndicator component

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Controls/AttitudeIndicator.axaml
+++ b/src/Asv.Drones.Gui.Uav/Controls/AttitudeIndicator.axaml
@@ -142,7 +142,7 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
-                        <Polygon Canvas.Left="480" Canvas.Top="200" Width="40" Height="20" Stretch="Fill" Points="0,1 1,0 2,1" Fill="#e53935" StrokeThickness="0.5" />
+                        <Polygon Canvas.Left="480" Canvas.Top="200" Width="40" Height="20" Stretch="Fill" Points="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RollPolygonPoints}" Fill="#e53935" StrokeThickness="0.5" />
                         <Line StartPoint="150,500" EndPoint="250,500" Stroke="#e53935" StrokeThickness="10"/>
                         <Line StartPoint="750,500" EndPoint="850,500" Stroke="#e53935" StrokeThickness="10"/>
                         <Line StartPoint="400,500" EndPoint="600,500" Stroke="#e0e0e0" StrokeThickness="5"/>
@@ -174,7 +174,7 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
-                        <Polygon ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Velocity_ToolTip}" Opacity="0.7" Canvas.Top="470" Canvas.Left="-1" Points="2,5 2,55 90,55 105,30 90,5" Fill="#000a12" StrokeThickness="3" Stroke="#eceff1"/>
+                        <Polygon ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Velocity_ToolTip}" Opacity="0.7" Canvas.Top="470" Canvas.Left="-1" Points="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=VelocityPolygonPoints}" Fill="#000a12" StrokeThickness="3" Stroke="#eceff1"/>
                         <TextBlock ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Velocity_ToolTip}" Canvas.Left="-1" Canvas.Top="470" Margin="0,0,0,0" Foreground="White" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Velocity}"
                                    TextAlignment="Right" FontSize="40" Width="87" FontWeight="DemiBold"/>
                         <Border ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Velocity_ToolTip}" BorderBrush="#e0e0e0" Canvas.Top="300"  Canvas.Left="-3" BorderThickness="5" CornerRadius="3" Width="113" Height="400"/>
@@ -204,7 +204,7 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
-                        <Polygon ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Altitude_ToolTip}" Opacity="0.7" Canvas.Right="-1" Canvas.Top="470" Points="105,5 105,55 15,55 0,30 15,5" Fill="#000a12" StrokeThickness="3" Stroke="#eceff1"/>
+                        <Polygon ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Altitude_ToolTip}" Opacity="0.7" Canvas.Right="-1" Canvas.Top="470" Points="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=AltitudePolygonPoints}" Fill="#000a12" StrokeThickness="3" Stroke="#eceff1"/>
                         <TextBlock ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Altitude_ToolTip}" Canvas.Right="-1" Canvas.Top="470" Margin="0,0,0,0" Foreground="White" FontWeight="DemiBold" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Altitude}"
                                    VerticalAlignment="Center" TextAlignment="Left" FontSize="40" Width="87"/>
                         <Border ToolTip.Tip="{x:Static controls:RS.AttitudeIndicator_Altitude_ToolTip}" BorderBrush="#e0e0e0" Canvas.Right="-3" Canvas.Top="300" BorderThickness="5" CornerRadius="3" Width="113" Height="400"/>
@@ -240,7 +240,7 @@
                                    VerticalAlignment="Center" TextAlignment="Center" FontWeight="DemiBold" FontSize="45" Width="80"/>
 
                             <!-- Home -->
-                            <Polygon Canvas.Top="2" Canvas.Left="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=HomeAzimuthPosition}" Points="-15,0 0,15 15,0" Fill="#e53935" StrokeThickness="3" Stroke="Red"/>
+                            <Polygon Canvas.Top="2" Canvas.Left="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=HomeAzimuthPosition}" Points="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=HomePolygonPoints}" Fill="#e53935" StrokeThickness="3" Stroke="Red"/>
 
                             
                             <!-- Vibration -->

--- a/src/Asv.Drones.Gui.Uav/Controls/AttitudeIndicator.axaml.cs
+++ b/src/Asv.Drones.Gui.Uav/Controls/AttitudeIndicator.axaml.cs
@@ -209,6 +209,42 @@ namespace Asv.Drones.Gui.Uav
             get => GetValue(ArmedTimeProperty);
             set => SetValue(ArmedTimeProperty, value);
         }
+        
+        public static readonly StyledProperty<List<Point>> AltitudePolygonPointsProperty =
+            AvaloniaProperty.Register<AttitudeIndicator, List<Point>>(nameof(AltitudePolygonPoints), new List<Point>());
+
+        public List<Point> AltitudePolygonPoints
+        {
+            get => GetValue(AltitudePolygonPointsProperty);
+            set => SetValue(AltitudePolygonPointsProperty, value);
+        }
+        
+        public static readonly StyledProperty<List<Point>> VelocityPolygonPointsProperty =
+            AvaloniaProperty.Register<AttitudeIndicator, List<Point>>(nameof(VelocityPolygonPoints), new List<Point>());
+
+        public List<Point> VelocityPolygonPoints
+        {
+            get => GetValue(VelocityPolygonPointsProperty);
+            set => SetValue(VelocityPolygonPointsProperty, value);
+        }
+        
+        public static readonly StyledProperty<List<Point>> HomePolygonPointsProperty =
+            AvaloniaProperty.Register<AttitudeIndicator, List<Point>>(nameof(HomePolygonPoints), new List<Point>());
+
+        public List<Point> HomePolygonPoints
+        {
+            get => GetValue(HomePolygonPointsProperty);
+            set => SetValue(HomePolygonPointsProperty, value);
+        }
+        
+        public static readonly StyledProperty<List<Point>> RollPolygonPointsProperty =
+            AvaloniaProperty.Register<AttitudeIndicator, List<Point>>(nameof(RollPolygonPoints), new List<Point>());
+
+        public List<Point> RollPolygonPoints
+        {
+            get => GetValue(RollPolygonPointsProperty);
+            set => SetValue(RollPolygonPointsProperty, value);
+        }
 
         #region Internal direct property
 
@@ -375,6 +411,8 @@ namespace Asv.Drones.Gui.Uav
             var headingItemStep = (headingControlLength + headingItemLength) / (HeadingItemCount % 2 != 0 ? HeadingItemCount - 1 : HeadingItemCount);
             _headingPositionStep = -1 * headingItemStep / HeadingValueRange;
             _headingCenterPosition = headingControlLength / 2;
+            
+            SetUpPolygonPoints();
         }
 
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -544,6 +582,30 @@ namespace Asv.Drones.Gui.Uav
                 distance -= 360;
 
             return _headingCenterPosition + distance * _headingPositionStep;
+        }
+
+        //TODO: Remove this and polygon styled properties when Avalonia will fix Points nullable attributes
+        private void SetUpPolygonPoints()
+        {
+            AltitudePolygonPoints.Add(new Point(105,5));
+            AltitudePolygonPoints.Add(new Point(105,55));
+            AltitudePolygonPoints.Add(new Point(15,55));
+            AltitudePolygonPoints.Add(new Point(0,30));
+            AltitudePolygonPoints.Add(new Point(15,5));
+            
+            VelocityPolygonPoints.Add(new Point(2,5));
+            VelocityPolygonPoints.Add(new Point(2,55));
+            VelocityPolygonPoints.Add(new Point(90,55));
+            VelocityPolygonPoints.Add(new Point(105,30));
+            VelocityPolygonPoints.Add(new Point(90,5));
+            
+            HomePolygonPoints.Add(new Point(-15,0));
+            HomePolygonPoints.Add(new Point(0,15));
+            HomePolygonPoints.Add(new Point(15,0));
+            
+            RollPolygonPoints.Add(new Point(0,1));
+            RollPolygonPoints.Add(new Point(1,0));
+            RollPolygonPoints.Add(new Point(2,1));
         }
     }
 


### PR DESCRIPTION
Introduced Styled Properties for different PolygonPoints (Altitude, Velocity, Roll, Home) in the AttitudeIndicator component. It allows points of polygons to be changed dynamically. This was necessary due to an issue with Avalonia's handling of nullable Point attributes, requiring us to set up static points for components through C# code-behind until the issue is resolved in the Avalonia framework. Also, references in XAML were updated to reflect these changes.

Asana: https://app.asana.com/0/1203851531040615/1204953971605269/f