### PR TITLE
fix: prevent plugin loading in design mode

### DIFF
--- a/src/Asv.Drones.Gui/App.axaml.cs
+++ b/src/Asv.Drones.Gui/App.axaml.cs
@@ -63,6 +63,9 @@ public partial class App : Application
                 }
             }
         }
+        
+        // This is done so that plugins won't load in design time
+        if (Design.IsDesignMode) _plugins.Clear();
 
         #endregion
     }


### PR DESCRIPTION
Modified App.axaml.cs file to prevent plugin loading during design time. This was done by checking the status of DesignMode and if true, clearing the _plugins. This change increases efficiency as plugins are not needed during design time.

Asana: https://app.asana.com/0/1203851531040615/1204963250497035/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204963250497035