### PR TITLE
fix: update color scheme for TextBlocks and MaterialIcons

### DIFF
--- a/src/Asv.Drones.Gui.Core/Controls/OptionsDisplayItem/OptionsDisplayItemStyles.axaml
+++ b/src/Asv.Drones.Gui.Core/Controls/OptionsDisplayItem/OptionsDisplayItemStyles.axaml
@@ -45,7 +45,8 @@
                                      Width="24" Height="24"
                                      Grid.RowSpan="2"
                                      Margin="8 4 12 4">
-                                <ContentPresenter Content="{TemplateBinding Icon}" />
+                                <ContentPresenter Content="{TemplateBinding Icon}"
+                                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
                             </Viewbox>
 
                             <TextBlock Text="{TemplateBinding Header}"
@@ -57,7 +58,6 @@
 
                             <TextBlock Text="{TemplateBinding Description}"
                                        Classes="CaptionTextBlockStyle"
-                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Top"
                                        TextWrapping="Wrap"
                                        Grid.Column="1"
@@ -74,7 +74,8 @@
                                            Margin="8 4"
                                            Grid.Column="3"
                                            Grid.RowSpan="2"
-                                           FontSize="20"/> 
+                                           FontSize="20"
+                                           Foreground="{DynamicResource TextFillColorPrimaryBrush}" /> 
                         </Grid>
                     </Border>
                    

--- a/src/Asv.Drones.Gui/App.axaml
+++ b/src/Asv.Drones.Gui/App.axaml
@@ -12,5 +12,12 @@
         <StyleInclude Source="avares://Asv.Drones.Gui.Map/App.axaml"/>
         <StyleInclude Source="avares://Asv.Drones.Gui.Core/App.axaml"/>
         <StyleInclude Source="avares://Asv.Drones.Gui.Uav/App.axaml"/>
+        
+        <Style Selector="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
+        <Style Selector="avalonia|MaterialIcon">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
     </Application.Styles>
 </Application>


### PR DESCRIPTION
Added DynamicResource TextFillPrimaryColorBrush as the Foreground value to TextBlock and MaterialIcon Style selectors in App.axaml file. The change has also been made to OptionsDisplayItemStyles.axaml file. This update ensures text and icons across the application use the primary color defined in the theme for consistency and better visual hierarchy.

Asana: https://app.asana.com/0/1203851531040615/1204953970281511/f