### PR TITLE
fix: refactor ViewModel initialization to use using declarations

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/ConnectionsPortsViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/ConnectionsPortsViewModel.cs
@@ -68,11 +68,10 @@ namespace Asv.Drones.Gui.Core
                 IsSecondaryButtonEnabled = true,
                 CloseButtonText = RS.ConnectionsViewModel_AddDialogPort_Cancel
             };
-            var viewModel = new SerialPortViewModel(_deviceSvc, _logService);
+            using var viewModel = new SerialPortViewModel(_deviceSvc, _logService);
             viewModel.ApplyDialog(dialog);
             dialog.Content = viewModel;
             var result = await dialog.ShowAsync();
-
         }
 
         private async Task AddTcpPort(CancellationToken cancel)
@@ -84,11 +83,10 @@ namespace Asv.Drones.Gui.Core
                 IsSecondaryButtonEnabled = true,
                 CloseButtonText = RS.ConnectionsViewModel_AddDialogPort_Cancel
             };
-            var viewModel = new TcpPortViewModel(_deviceSvc,_logService);
+            using var viewModel = new TcpPortViewModel(_deviceSvc,_logService);
             viewModel.ApplyDialog(dialog);
             dialog.Content = viewModel;
             var result = await dialog.ShowAsync();
-
         }
 
         private async Task AddUdpPort(CancellationToken cancel)
@@ -100,11 +98,10 @@ namespace Asv.Drones.Gui.Core
                 IsSecondaryButtonEnabled = true,
                 CloseButtonText = RS.ConnectionsViewModel_AddDialogPort_Cancel
             };
-            var viewModel = new UdpPortViewModel(_deviceSvc);
+            using var viewModel = new UdpPortViewModel(_deviceSvc);
             viewModel.ApplyDialog(dialog);
             dialog.Content = viewModel;
             var result = await dialog.ShowAsync();
-
         }
 
         public ReadOnlyObservableCollection<PortViewModel> Items => _items;

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/PortViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/PortViewModel.cs
@@ -196,7 +196,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     dialog.Title = RS.ConnectionsViewModel_EditSerialPortDialog_Title;
                     
-                    var viewModel = new SerialPortViewModel(_svc, _logService);
+                    using var viewModel = new SerialPortViewModel(_svc, _logService);
                     
                     viewModel.Title = info.Name;
 
@@ -217,7 +217,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     dialog.Title = RS.ConnectionsViewModel_EditTcpPortDialog_Title;
                     
-                    var viewModel = new TcpPortViewModel(_svc, _logService);
+                    using var viewModel = new TcpPortViewModel(_svc, _logService);
                     
                     viewModel.Title = info.Name;
                     
@@ -243,7 +243,7 @@ namespace Asv.Drones.Gui.Core
                 {
                     dialog.Title = RS.ConnectionsViewModel_EditUdpPortDialog_Title;
                     
-                    var viewModel = new UdpPortViewModel(_svc);
+                    using var viewModel = new UdpPortViewModel(_svc);
                     
                     viewModel.Title = info.Name;
                     
@@ -270,6 +270,7 @@ namespace Asv.Drones.Gui.Core
             if (await dialog.ShowAsync() == ContentDialogResult.Primary)
             {
                 _svc.Router.RemovePort(_id);
+                
             }
         }
         

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/PacketViewer/PacketViewerViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/PacketViewer/PacketViewerViewModel.cs
@@ -230,7 +230,7 @@ public class PacketViewerViewModel : ViewModelBase, IShellPage
             SecondaryButtonText = RS.PacketViewerViewModel_SeparatorDialog_DialogSecondaryButton
         };
             
-        var viewModel = new SeparatorViewModel();
+        using var viewModel = new SeparatorViewModel();
         viewModel.ApplyDialog(dialog);
         dialog.Content = viewModel;
             

--- a/src/Asv.Drones.Gui.Gbs/Shell/Pages/Flight/Widgets/Gbs/Dialogs/FixedModeViewModel.cs
+++ b/src/Asv.Drones.Gui.Gbs/Shell/Pages/Flight/Widgets/Gbs/Dialogs/FixedModeViewModel.cs
@@ -140,7 +140,7 @@ public class FixedModeViewModel : ViewModelBaseWithValidation
             CloseButtonText = RS.FixedModeViewModel_SetCoordsName_SecondaryButtonText
         };
 
-        var vm = new SetCoordsNameViewModel();
+        using var vm = new SetCoordsNameViewModel();
         dialog.Content = vm;
         var result = await dialog.ShowAsync();
 

--- a/src/Asv.Drones.Gui.Gbs/Shell/Pages/Flight/Widgets/Gbs/FlightGbsViewModel.cs
+++ b/src/Asv.Drones.Gui.Gbs/Shell/Pages/Flight/Widgets/Gbs/FlightGbsViewModel.cs
@@ -147,7 +147,7 @@ public class FlightGbsViewModel:FlightGbsWidgetBase
             CloseButtonText = RS.FlightGbsViewModel_AutoMode_CloseButtonText
         };
 
-        var viewModel = new AutoModeViewModel(BaseStation, _logService, _loc, _configuration, ctx);
+        using var viewModel = new AutoModeViewModel(BaseStation, _logService, _loc, _configuration, ctx);
         viewModel.ApplyDialog(dialog);
         dialog.Content = viewModel;
         await dialog.ShowAsync();
@@ -163,7 +163,7 @@ public class FlightGbsViewModel:FlightGbsWidgetBase
             CloseButtonText = RS.FlightGbsViewModel_FixedMode_CloseButtonText
         };
 
-        var viewModel = new FixedModeViewModel(BaseStation, _logService, _loc, _configuration, ctx);
+        using var viewModel = new FixedModeViewModel(BaseStation, _logService, _loc, _configuration, ctx);
         viewModel.ApplyDialog(dialog);
         dialog.Content = viewModel;
         await dialog.ShowAsync();

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -106,7 +106,7 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
             SecondaryButtonText = "Cancel"
         };
             
-        var viewModel = new RecordStartViewModel();
+        using var viewModel = new RecordStartViewModel();
             
         viewModel.ApplyDialog(dialog);
             

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/RebootAutopilotAnchorActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/RebootAutopilotAnchorActionViewModel.cs
@@ -34,7 +34,7 @@ public class RebootAutopilotAnchorActionViewModel : UavActionActionBase
             SecondaryButtonText = RS.RebootAutopilotAnchorActionViewModel_DialogSecondaryButton
         };
 
-        var viewModel = new RebootAutopilotViewModel();
+        using var viewModel = new RebootAutopilotViewModel();
         dialog.Content = viewModel;
 
         var result = await dialog.ShowAsync();

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/SelectModeAnchorActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/SelectModeAnchorActionViewModel.cs
@@ -39,7 +39,7 @@ public class SelectModeAnchorActionViewModel : UavActionActionBase
             SecondaryButtonText = RS.SelectModeAnchorActionViewModel_DialogSecondaryButton
         });
         
-        var viewModel = new SelectModeViewModel(Vehicle);
+        using var viewModel = new SelectModeViewModel(Vehicle);
         dialog.Content = viewModel;
 
         var result = await dialog.ShowAsync();

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/TakeOffAnchorActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/TakeOffAnchorActionViewModel.cs
@@ -50,7 +50,7 @@ namespace Asv.Drones.Gui.Uav
                 SecondaryButtonText = RS.TakeOffAnchorActionViewModel_DialogSecondaryButton
             };
             
-            var viewModel = new TakeOffViewModel(_cfg, _loc);
+            using var viewModel = new TakeOffViewModel(_cfg, _loc);
             viewModel.ApplyDialog(dialog);
             dialog.Content = viewModel;
             

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
@@ -73,7 +73,7 @@ namespace Asv.Drones.Gui.Uav
                     SecondaryButtonText = RS.SelectModeAnchorActionViewModel_DialogSecondaryButton
                 };
         
-                var viewModel = new SelectModeViewModel(Vehicle);
+                using var viewModel = new SelectModeViewModel(Vehicle);
                 dialog.Content = viewModel;
 
                 var result = await dialog.ShowAsync();


### PR DESCRIPTION
This commit updates ViewModel initialization across various files to use 'using' declarations, thus ensuring that the objects gets properly disposed to free resources. This change makes the code cleaner and more memory efficient, as the declared variables doesn't have the chance to escape their scope and can be immediately disposed of when they're no longer in use.

Asana: https://app.asana.com/0/1203851531040615/1204971171054340/f