### PR TITLE
fix: add styles for disabled TextBlock and MaterialIcon

### DIFF
--- a/src/Asv.Drones.Gui/App.axaml
+++ b/src/Asv.Drones.Gui/App.axaml
@@ -16,8 +16,14 @@
         <Style Selector="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
         </Style>
+        <Style Selector="TextBlock:disabled">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+        </Style>
         <Style Selector="avalonia|MaterialIcon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        </Style>
+        <Style Selector="avalonia|MaterialIcon:disabled">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
         </Style>
     </Application.Styles>
 </Application>


### PR DESCRIPTION
In the Asv.Drones.Gui application, additional styling has been provided for both TextBlock and MaterialIcon when in disabled state. These new styles update the foreground color to utilize the `TextFillColorDisabledBrush` dynamic resource instead of the regular `TextFillColorPrimaryBrush`, aiming to provide a better visual hint on element's state to users.

Asana: https://app.asana.com/0/1203851531040615/1205007794960756/f