### PR TITLE
fix: update vehicle current mode dynamically

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/SelectModeAnchorActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Layers/Anchors/UavAnchor/Actions/SelectModeAnchorActionViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using Asv.Common;
 using Asv.Drones.Gui.Core;
 using Asv.Drones.Uav;
 using Asv.Mavlink;
@@ -14,11 +15,11 @@ namespace Asv.Drones.Gui.Uav;
 public class SelectModeAnchorActionViewModel : UavActionActionBase
 {
     private readonly ILogService _log;
-    private readonly string _initialModeName;
+    private string _initialModeName;
     public SelectModeAnchorActionViewModel(IVehicleClient vehicle, IMap map, ILogService log) : base(vehicle, map, log)
     {
         _log = log;
-        _initialModeName = vehicle.CurrentMode.Value.Name;
+        vehicle.CurrentMode.Subscribe(_ => _initialModeName = _.Name).DisposeItWith(Disposable);
         Title = RS.SelectModeAnchorActionViewModel_Title;
         Icon = MaterialIconKind.ModeEdit;
         Vehicle.Position.IsArmed.Select(_ => _).Subscribe(CanExecute).DisposeWith(Disposable);

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
@@ -43,8 +43,8 @@ namespace Asv.Drones.Gui.Uav
             Icon = MavlinkHelper.GetIcon(vehicle.Class);
             Attitude = new AttitudeViewModel(vehicle, new Uri(Id, "/id"),loc);
             MissionStatus = new MissionStatusViewModel(vehicle, log, new Uri(Id, "/id"),loc);
-            CurrentMode = new VehicleModeWithIcons(Vehicle.CurrentMode.Value);
-            
+            Vehicle.CurrentMode.Subscribe(_ => CurrentMode = new VehicleModeWithIcons(_)).DisposeItWith(Disposable);
+
             rttItems
                 .SelectMany(_ => _.Create(Vehicle))
                 .OrderBy(_=>_.Order)


### PR DESCRIPTION
Modified the Vehicle.CurrentMode initialization way in both FlightUavViewModel and SelectModeAnchorActionViewModel files. Instead of initializing it with the vehicle's current mode during instantiation time, it now subscribes to the Vehicle.CurrentMode changes. It ensures that the CurrentMode on the UI will be updated whenever the Vehicle's CurrentMode gets updated in the backend.

This change was necessary to keep the UI view synchronized with the backend vehicle current mode, especially when it changes after the object creation. Thus, users will always see the current and actual mode of the vehicle in the UI.

Asana: https://app.asana.com/0/1203851531040615/1204961236602308/f