### PR TITLE
fix: change default ruler visibility upon map loading

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Actions/Ruler/MapRulerActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Actions/Ruler/MapRulerActionViewModel.cs
@@ -22,7 +22,7 @@ public class MapRulerActionViewModel:MapActionBase
     protected override void InternalWhenMapLoaded(IMap context)
     {
         base.InternalWhenMapLoaded(context);
-        SetUpRuler(true);
+        SetUpRuler(false);
     }
 
     private async void SetUpRuler(bool isVisible)


### PR DESCRIPTION
The default state of the ruler when the map is loaded has been changed from visible to hidden. This is to improve the initial user experience by reducing clutter and promoting a cleaner UI. Further interactions with the ruler can be made by the user as needed.

Asana: https://app.asana.com/0/1203851531040615/1205041729023507/f