### PR TITLE
feat(sdr): add safe OS reboot and shutdown commands

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -60,6 +60,24 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reboot OS.
+        /// </summary>
+        public static string FlightSdrView_SystemControlAction_Reboot_Title {
+            get {
+                return ResourceManager.GetString("FlightSdrView_SystemControlAction_Reboot_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shutdown OS.
+        /// </summary>
+        public static string FlightSdrView_SystemControlAction_Shutdown_Title {
+            get {
+                return ResourceManager.GetString("FlightSdrView_SystemControlAction_Shutdown_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to AM 150 Hz.
         /// </summary>
         public static string IlsSdrRttViewModel_AM_150_Hz_Title {

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -99,4 +99,10 @@
     <data name="VorSdrRttViewModelFMIndexTitle" xml:space="preserve">
         <value>FM Index</value>
     </data>
+    <data name="FlightSdrView_SystemControlAction_Reboot_Title" xml:space="preserve">
+        <value>Reboot OS</value>
+    </data>
+    <data name="FlightSdrView_SystemControlAction_Shutdown_Title" xml:space="preserve">
+        <value>Shutdown OS</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -92,4 +92,10 @@
     <data name="VorSdrRttViewModelFMIndexTitle" xml:space="preserve">
         <value>Индекс ЧМ</value>
     </data>
+    <data name="FlightSdrView_SystemControlAction_Reboot_Title" xml:space="preserve">
+        <value>Перезагрузить ОС</value>
+    </data>
+    <data name="FlightSdrView_SystemControlAction_Shutdown_Title" xml:space="preserve">
+        <value>Выключить ОС</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:sdr="clr-namespace:Asv.Drones.Gui.Sdr"
+             xmlns:core="clr-namespace:Asv.Drones.Gui.Core;assembly=Asv.Drones.Gui.Core"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:CompileBindings="True"
              x:DataType="sdr:FlightSdrViewModel"
@@ -21,12 +22,32 @@
                     <avalonia:MaterialIcon DockPanel.Dock="Left" Kind="RecordRec" Foreground="Gray"  Width="25" Height="25" />
                 </Button>
                 
-                <Button  DockPanel.Dock="Left" Padding="3" BorderBrush="Transparent" BorderThickness="0" Background="Transparent" >
+                <DropDownButton DockPanel.Dock="Left" Padding="3" BorderBrush="Transparent" BorderThickness="0" Background="Transparent" >
                     <StackPanel Orientation="Horizontal">
                         <avalonia:MaterialIcon DockPanel.Dock="Left" Kind="{Binding Icon}" Foreground="BlueViolet"  Width="25" Height="25" Margin="0,0,5,0"/>
                         <TextBlock VerticalAlignment="Center" DockPanel.Dock="Top" Text="{Binding Title}" />      
                     </StackPanel>
-                </Button>
+                    <DropDownButton.Flyout>
+                        <MenuFlyout Placement="Bottom">
+                            <MenuItem  Command="{CompiledBinding SafeRebootOSCommand}">
+                                <MenuItem.Header>
+                                    <StackPanel Orientation="Horizontal" Spacing="3">
+                                        <avalonia:MaterialIcon Kind="Refresh" />
+                                        <TextBlock Text="{x:Static sdr:RS.FlightSdrView_SystemControlAction_Reboot_Title}" />
+                                    </StackPanel>
+                                </MenuItem.Header>
+                            </MenuItem>
+                            <MenuItem Command="{CompiledBinding SafeShutdownOSCommand}">
+                                <MenuItem.Header>
+                                    <StackPanel Orientation="Horizontal" Spacing="3">
+                                        <avalonia:MaterialIcon Kind="Power" Foreground="Red" />
+                                        <TextBlock Text="{x:Static sdr:RS.FlightSdrView_SystemControlAction_Shutdown_Title}" />
+                                    </StackPanel>
+                                </MenuItem.Header>
+                            </MenuItem>
+                        </MenuFlyout>
+                    </DropDownButton.Flyout>
+                </DropDownButton>
                 
                 <sdr:LinkQualitySdrRttView DataContext="{CompiledBinding LinkQuality}" DockPanel.Dock="Left" Padding="3" BorderBrush="Transparent" BorderThickness="0" Background="Transparent"/>
             </DockPanel>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using Asv.Cfg;
 using Asv.Common;
 using Asv.Drones.Gui.Core;
@@ -92,6 +93,11 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
         });
         
         LinkQuality = new LinkQualitySdrRttViewModel(payload);
+        
+        SafeRebootOSCommand = ReactiveCommand.CreateFromTask(cancel =>
+            payload.Sdr.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionReboot, cancel));
+        SafeShutdownOSCommand = ReactiveCommand.CreateFromTask(cancel =>
+            payload.Sdr.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown, cancel));
     }
     
     private async Task RecordStartImpl(CancellationToken cancel)
@@ -187,6 +193,8 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
     public ReactiveCommand<Unit,Unit> UpdateMode { get; }
     public ReactiveCommand<Unit,Unit> StartRecord { get; }
     public ReactiveCommand<Unit,Unit> StopRecord { get; }
+    public ICommand SafeRebootOSCommand { get; set; }
+    public ICommand SafeShutdownOSCommand { get; set; }
 }
 public class SdrModeViewModel:ReactiveObject
 {

--- a/src/Asv.Drones.Gui/Asv.Drones.Gui.csproj
+++ b/src/Asv.Drones.Gui/Asv.Drones.Gui.csproj
@@ -8,7 +8,7 @@
         <FileVersion>$(ProductExtendedVersion)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <DefineConstants>TRACE</DefineConstants>
+        <DefineConstants>TRACE;PROPRIETARY</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DefineConstants>TRACE;PROPRIETARY</DefineConstants>


### PR DESCRIPTION
This commit introduces two new system control actions: 'Reboot OS' and 'Shutdown OS' to the flight SDR view. The changes include necessary updates in related view models and localized strings for both English and Russian language. These actions provide a user with a capability to safely reboot or shutdown the operating system from the user interface. The new controls are designed as options in a dropdown menu for convenience.

Asana: https://app.asana.com/0/1203851531040615/1205007794960754/f