### PR TITLE
fix(uav): update Map follow state for UAV widgets

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/FlightUavViewModel.cs
@@ -124,6 +124,15 @@ namespace Asv.Drones.Gui.Uav
             {
                 Map.ItemToFollow = null;
                 
+                if (Map is MapPageViewModel vm)
+                {
+                    var uavWidgets = vm.LeftWidgets.OfType<FlightUavViewModel>();
+                    foreach (var uavWidget in uavWidgets)
+                    {
+                        uavWidget.IsFollowed = false;
+                    }
+                }
+                
                 var findUavVehicle = Map.Markers.Where(_ => _ is UavAnchor).Cast<UavAnchor>()
                     .FirstOrDefault(_ => _.Vehicle.FullId == Vehicle.FullId);
                 


### PR DESCRIPTION
The map's UAV widget follow state was not being properly updated when the map item to follow was set to null. This change ensures that all of the UAV widgets are set to 'not followed' when the map item to follow is made null. This will prevent inconsistencies in the follow-status between the map and the UAV widgets.

Asana: https://app.asana.com/0/1203851531040615/1205044822709643/f