### PR TITLE
feat(sdr): Change frequency unit from Hz to MHz in FlightSdr ViewModel and View

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -60,6 +60,15 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MHz.
+        /// </summary>
+        public static string FlightSdrView_Frequency_MHz_Units {
+            get {
+                return ResourceManager.GetString("FlightSdrView_Frequency_MHz_Units", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Reboot OS.
         /// </summary>
         public static string FlightSdrView_SystemControlAction_Reboot_Title {

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -144,4 +144,7 @@
     <data name="VorSdrRttViewModel_FieldStrength_Units" xml:space="preserve">
         <value>μV/m</value>
     </data>
+    <data name="FlightSdrView_Frequency_MHz_Units" xml:space="preserve">
+        <value>MHz</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -137,4 +137,7 @@
     <data name="VorSdrRttViewModel_FieldStrength_Units" xml:space="preserve">
         <value>μВ/м</value>
     </data>
+    <data name="FlightSdrView_Frequency_MHz_Units" xml:space="preserve">
+        <value>МГц</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
@@ -61,7 +61,11 @@
                    </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBox Text="{Binding Frequency}"/>
+            <TextBox Text="{Binding FrequencyInMhz}">
+                <TextBox.InnerRightContent>
+                    <TextBlock Margin="8 0" Text="{x:Static sdr:RS.FlightSdrView_Frequency_MHz_Units}" VerticalAlignment="Center" />
+                </TextBox.InnerRightContent>
+            </TextBox>
             <Button Command="{Binding UpdateMode}" HorizontalAlignment="Stretch">Set</Button>
             <ItemsControl ItemsSource="{Binding RttWidgets}">
                 <ItemsControl.ItemsPanel>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -63,7 +63,7 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
         
        
         
-        UpdateMode = ReactiveCommand.CreateFromTask(cancel=>Payload.Sdr.SetModeAndCheckResult(SelectedMode.Mode,Frequency,1,1,cancel));
+        UpdateMode = ReactiveCommand.CreateFromTask(cancel=>Payload.Sdr.SetModeAndCheckResult(SelectedMode.Mode,FrequencyInMhz * 1_000_000,1,1,cancel));
         UpdateMode.ThrownExceptions.Subscribe(ex =>
         {
             _logService.Error("Set mode",$"Error to set payload mode",ex); // TODO: Localize
@@ -184,7 +184,7 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
     [Reactive]
     public SdrModeViewModel? SelectedMode { get; set; }
     [Reactive]
-    public ulong Frequency { get; set; }
+    public ulong FrequencyInMhz { get; set; }
     [Reactive]
     public bool IsRecordStarted { get; set; }
     


### PR DESCRIPTION
Changed parameter name from 'Frequency' to 'FrequencyInMhz' in the FlightSdrViewModel and updated the related data binding in FlightSdrView. This change will make the frequency input more user-friendly as users typically think in MHz, not Hz when working with drones.

Asana: https://app.asana.com/0/1203851531040615/1205044869965347/f