### PR TITLE
fix (core): fix startup theme on Android

### DIFF
--- a/src/Asv.Drones.Gui.Core/Services/Theme/IThemeService.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Theme/IThemeService.cs
@@ -18,24 +18,10 @@ namespace Asv.Drones.Gui.Core
         public ThemeVariant Theme { get; }
     }
 
-    public class FlowDirectionItem
-    {
-        public FlowDirectionItem(FlowDirection id, string name)
-        {
-            Id = id;
-            Name = name;
-        }
-
-        public FlowDirection Id { get; }
-        public string Name { get; }
-    }
-
 
     public interface IThemeService
     {
         IEnumerable<ThemeItem> Themes { get; }
         IRxEditableValue<ThemeItem> CurrentTheme { get; }
-        IRxEditableValue<FlowDirectionItem> FlowDirection { get; }
-        IEnumerable<FlowDirectionItem> FlowDirections { get; }
     }
 }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/Theme/SettingsThemeView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/Theme/SettingsThemeView.axaml
@@ -14,7 +14,6 @@
         <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static core:RS.SettingsThemeViewModel_CurrentTheme}"
                                  Icon="DarkTheme"
                                  Description="{x:Static core:RS.SettingsThemeViewModel_ChangeThemeDescription}">
-
             <core:OptionsDisplayItem.ActionButton>
                 <ComboBox SelectedItem="{Binding SelectedTheme}"
                           ItemsSource="{Binding AppThemes}"
@@ -26,12 +25,10 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
             </core:OptionsDisplayItem.ActionButton>
-
-        </core:OptionsDisplayItem >
+        </core:OptionsDisplayItem>
         <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static core:RS.SettingsThemeViewModel_CurrentLanguage}"
                                  Icon="{Binding LanguageIcon}"
                                  Description="{x:Static core:RS.SettingsThemeViewModel_CurrentLanguageDescription}">
-
             <core:OptionsDisplayItem.ActionButton>
                 <ComboBox SelectedItem="{Binding SelectedLanguage}"
                           ItemsSource="{Binding AppLanguages}"
@@ -43,26 +40,6 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
             </core:OptionsDisplayItem.ActionButton>
-
         </core:OptionsDisplayItem >
-        <core:OptionsDisplayItem Header="{x:Static core:RS.SettingsThemeViewModel_FlowDirection}"
-                                 Icon="AlignRight"
-                                 Description="{x:Static core:RS.SettingsThemeViewModel_FlowDirectionDescription}">
-
-            <core:OptionsDisplayItem.ActionButton>
-                <ComboBox SelectedItem="{Binding FlowDirection}"
-                          ItemsSource="{Binding AppFlowDirections}"
-                          MinWidth="150">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding Name}"/>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-				</ComboBox>
-            </core:OptionsDisplayItem.ActionButton>
-
-        </core:OptionsDisplayItem>
-        
-        
 	</StackPanel>
 </UserControl>

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/Theme/SettingsThemeViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/Theme/SettingsThemeViewModel.cs
@@ -38,14 +38,6 @@ namespace Asv.Drones.Gui.Core
                 .Subscribe(_themeService.CurrentTheme)
                 .DisposeItWith(Disposable);
 
-            _themeService.FlowDirection.Subscribe(_ => FlowDirection = _)
-                .DisposeItWith(Disposable);
-            
-            this.WhenAnyValue(_ => _.FlowDirection)
-                .Skip(1) // skip first because it is set in constructor
-                .Subscribe(_themeService.FlowDirection)
-                .DisposeItWith(Disposable);
-
             this.WhenAnyValue(_ => _.SelectedLanguage)
                 .Skip(1) // skip first because it is set in constructor
                 .Subscribe(_ => IsRebootRequired = _ != _localization.CurrentLanguage.Value).DisposeItWith(Disposable);
@@ -61,11 +53,6 @@ namespace Asv.Drones.Gui.Core
 
         [Reactive]
         public ThemeItem SelectedTheme { get; set; }
-
-        [Reactive]
-        public FlowDirectionItem FlowDirection { get; set; }
-
-        public IEnumerable<FlowDirectionItem> AppFlowDirections => _themeService.FlowDirections;
 
         public string LanguageIcon => MaterialIconDataProvider.GetData(MaterialIconKind.Translate);
 

--- a/src/Asv.Drones.Gui.Core/Shell/ShellView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/ShellView.axaml
@@ -8,7 +8,8 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:CompileBindings="True"
              x:Class="Asv.Drones.Gui.Core.ShellView"
-             x:DataType="core:ShellViewModel">
+             x:DataType="core:ShellViewModel"
+             AttachedToVisualTree="OnAttachedToVisualTree">
     <Design.DataContext>
         <core:ShellViewModel/>
     </Design.DataContext>

--- a/src/Asv.Drones.Gui.Core/Shell/ShellView.axaml.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/ShellView.axaml.cs
@@ -22,4 +22,10 @@ public partial class ShellView : UserControl
     {
         
     }
+
+    private void OnAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs e)
+    {
+        var vm = this.DataContext as ShellViewModel;
+        vm?.OnLoaded();
+    }
 }


### PR DESCRIPTION
An `OnLoaded` event handler has been added to `ShellView.axaml.cs`. This allows `ShellViewModel` to load the theme from the config once the view is loaded. The `IThemeService` and `IConfiguration` dependencies were also added to the `ShellViewModel` constructor. This ensures that the preferred theme is applied when the ShellView is being rendered.

Also, the FlowDirection feature was removed from the ThemeService and all related implementations. This isn't necessary for the current functionalities of our application. This change simplifies the code by reducing redundant elements, focusing only on necessary features and also improves readability of the code. Future enhancements can consider adding it back if needed.

Asana: https://app.asana.com/0/1203851531040615/1204953970281515/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205149596306171