### PR TITLE
fix(core): prevent text overflow in PortView.axaml

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/PortView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Connections/Ports/PortView.axaml
@@ -53,8 +53,8 @@
             
             </Ellipse>
             <StackPanel Margin="5,0,0,0" Grid.Column="1" ToolTip.Tip="{Binding Description}">
-                <TextBlock Text="{Binding Name}" Theme="{DynamicResource SubtitleTextBlockStyle}"/>
-                <TextBlock Text="{Binding ConnectionString}" Theme="{DynamicResource CaptionTextBlockStyle}" />
+                <TextBlock TextWrapping="NoWrap" Text="{Binding Name}" Theme="{DynamicResource SubtitleTextBlockStyle}"/>
+                <TextBlock TextWrapping="NoWrap" Text="{Binding ConnectionString}" Theme="{DynamicResource CaptionTextBlockStyle}" />
                 <ToggleSwitch Margin="0,-8,0,0" Command="{Binding EnableDisableCommand}" OffContent="{x:Static core:RS.PortView_ToggleButton_Disabled}" OnContent="{x:Static core:RS.PortView_ToggleButton_Enabled}" IsChecked="{Binding IsPortEnabled}"/>
 			</StackPanel>
 			<StackPanel Grid.Column="3" Margin="10,5" >


### PR DESCRIPTION
Updated TextBlocks in PortView.axaml to prevent text overflow. 'Name' and 'ConnectionString' fields are now set to 'NoWrap', ensuring proper visibility and readability on fixed layout.

Asana: https://app.asana.com/0/1203851531040615/1205134815539037/f