### PR TITLE
feat (sdr): update frequency validation in FlightSdrViewModel and replace hardcoded strings with localized resources

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -87,6 +87,96 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start.
+        /// </summary>
+        public static string FlightSdrViewModel_RecordStartDialog_PrimarryButton_Name {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_RecordStartDialog_PrimarryButton_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string FlightSdrViewModel_RecordStartDialog_SecondaryButton_Name {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_RecordStartDialog_SecondaryButton_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New.
+        /// </summary>
+        public static string FlightSdrViewModel_RecordStartDialog_Title {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_RecordStartDialog_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error to set payload mode.
+        /// </summary>
+        public static string FlightSdrViewModel_StartRecord_Error_Message {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_StartRecord_Error_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rec start.
+        /// </summary>
+        public static string FlightSdrViewModel_StartRecord_Error_Sender {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_StartRecord_Error_Sender", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error to set payload mode.
+        /// </summary>
+        public static string FlightSdrViewModel_StopRecord_Error_Message {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_StopRecord_Error_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rec stop.
+        /// </summary>
+        public static string FlightSdrViewModel_StopRecord_Error_Sender {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_StopRecord_Error_Sender", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Payload.
+        /// </summary>
+        public static string FlightSdrViewModel_Title {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error to set payload mode.
+        /// </summary>
+        public static string FlightSdrViewModel_UpdateMode_Error_Message {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_UpdateMode_Error_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set mode.
+        /// </summary>
+        public static string FlightSdrViewModel_UpdateMode_Error_Sender {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_UpdateMode_Error_Sender", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SDR link quality.
         /// </summary>
         public static string LinkQualitySdrRttView_ToolTip {
@@ -245,6 +335,105 @@ namespace Asv.Drones.Gui.Sdr {
         public static string LlzSdrRttViewModelChannelTitle {
             get {
                 return ResourceManager.GetString("LlzSdrRttViewModelChannelTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add.
+        /// </summary>
+        public static string RecordStartView_AddButton_Title {
+            get {
+                return ResourceManager.GetString("RecordStartView_AddButton_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Record name.
+        /// </summary>
+        public static string RecordStartView_RecordName_Title {
+            get {
+                return ResourceManager.GetString("RecordStartView_RecordName_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter new record name.
+        /// </summary>
+        public static string RecordStartView_RecordName_Watermark {
+            get {
+                return ResourceManager.GetString("RecordStartView_RecordName_Watermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter new tag name.
+        /// </summary>
+        public static string RecordStartView_TagName_Watermark {
+            get {
+                return ResourceManager.GetString("RecordStartView_TagName_Watermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter new tag value.
+        /// </summary>
+        public static string RecordStartView_TagValue_Watermark {
+            get {
+                return ResourceManager.GetString("RecordStartView_TagValue_Watermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not valid record name.
+        /// </summary>
+        public static string RecordStartViewModel_RecordName_Validation_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_RecordName_Validation_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not valid tag name.
+        /// </summary>
+        public static string RecordStartViewModel_TagName_Validation_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_TagName_Validation_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is not valid Float64 value!.
+        /// </summary>
+        public static string RecordStartViewModel_TagValue_Float64_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_TagValue_Float64_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is not valid Int64 value!.
+        /// </summary>
+        public static string RecordStartViewModel_TagValue_Int64_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_TagValue_Int64_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to String length must be &lt; 9, and contain only ascii-chars!.
+        /// </summary>
+        public static string RecordStartViewModel_TagValue_String8_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_TagValue_String8_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is not valid UInt64 value!.
+        /// </summary>
+        public static string RecordStartViewModel_TagValue_UInt64_ErrorMessage {
+            get {
+                return ResourceManager.GetString("RecordStartViewModel_TagValue_UInt64_ErrorMessage", resourceCulture);
             }
         }
         

--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -78,6 +78,15 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value must be greater than 0.
+        /// </summary>
+        public static string FlightSdrViewModel_Frequency_Validation_ErrorMessage {
+            get {
+                return ResourceManager.GetString("FlightSdrViewModel_Frequency_Validation_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SDR link quality.
         /// </summary>
         public static string LinkQualitySdrRttView_ToolTip {

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -147,4 +147,67 @@
     <data name="FlightSdrViewModel_Frequency_Validation_ErrorMessage" xml:space="preserve">
         <value>Value must be greater than 0</value>
     </data>
+    <data name="FlightSdrViewModel_Title" xml:space="preserve">
+        <value>Payload</value>
+    </data>
+    <data name="FlightSdrViewModel_UpdateMode_Error_Sender" xml:space="preserve">
+        <value>Set mode</value>
+    </data>
+    <data name="FlightSdrViewModel_UpdateMode_Error_Message" xml:space="preserve">
+        <value>Error to set payload mode</value>
+    </data>
+    <data name="FlightSdrViewModel_StartRecord_Error_Sender" xml:space="preserve">
+        <value>Rec start</value>
+    </data>
+    <data name="FlightSdrViewModel_StartRecord_Error_Message" xml:space="preserve">
+        <value>Error to set payload mode</value>
+    </data>
+    <data name="FlightSdrViewModel_StopRecord_Error_Sender" xml:space="preserve">
+        <value>Rec stop</value>
+    </data>
+    <data name="FlightSdrViewModel_StopRecord_Error_Message" xml:space="preserve">
+        <value>Error to set payload mode</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_Title" xml:space="preserve">
+        <value>New</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_PrimarryButton_Name" xml:space="preserve">
+        <value>Start</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_SecondaryButton_Name" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="RecordStartViewModel_TagName_Validation_ErrorMessage" xml:space="preserve">
+        <value>Not valid tag name</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_String8_ErrorMessage" xml:space="preserve">
+        <value>String length must be &lt; 9, and contain only ascii-chars!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_Int64_ErrorMessage" xml:space="preserve">
+        <value>This is not valid Int64 value!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_UInt64_ErrorMessage" xml:space="preserve">
+        <value>This is not valid UInt64 value!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_Float64_ErrorMessage" xml:space="preserve">
+        <value>This is not valid Float64 value!</value>
+    </data>
+    <data name="RecordStartViewModel_RecordName_Validation_ErrorMessage" xml:space="preserve">
+        <value>Not valid record name</value>
+    </data>
+    <data name="RecordStartView_RecordName_Title" xml:space="preserve">
+        <value>Record name</value>
+    </data>
+    <data name="RecordStartView_RecordName_Watermark" xml:space="preserve">
+        <value>Enter new record name</value>
+    </data>
+    <data name="RecordStartView_TagName_Watermark" xml:space="preserve">
+        <value>Enter new tag name</value>
+    </data>
+    <data name="RecordStartView_TagValue_Watermark" xml:space="preserve">
+        <value>Enter new tag value</value>
+    </data>
+    <data name="RecordStartView_AddButton_Title" xml:space="preserve">
+        <value>Add</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -144,4 +144,7 @@
     <data name="VorSdrRttViewModel_FieldStrength_Units" xml:space="preserve">
         <value>μV/m</value>
     </data>
+    <data name="FlightSdrViewModel_Frequency_Validation_ErrorMessage" xml:space="preserve">
+        <value>Value must be greater than 0</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -140,4 +140,67 @@
     <data name="FlightSdrViewModel_Frequency_Validation_ErrorMessage" xml:space="preserve">
         <value>Значение должно быть больше 0</value>
     </data>
+    <data name="FlightSdrViewModel_Title" xml:space="preserve">
+        <value>Нагрузка</value>
+    </data>
+    <data name="FlightSdrViewModel_UpdateMode_Error_Sender" xml:space="preserve">
+        <value>Установить режим</value>
+    </data>
+    <data name="FlightSdrViewModel_UpdateMode_Error_Message" xml:space="preserve">
+        <value>Ошибка при установке режима полезной нагрузки</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_PrimarryButton_Name" xml:space="preserve">
+        <value>Начать</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_SecondaryButton_Name" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="FlightSdrViewModel_RecordStartDialog_Title" xml:space="preserve">
+        <value>Новая запись</value>
+    </data>
+    <data name="FlightSdrViewModel_StartRecord_Error_Message" xml:space="preserve">
+        <value>Ошибка при установке режима полезной нагрузки</value>
+    </data>
+    <data name="FlightSdrViewModel_StopRecord_Error_Message" xml:space="preserve">
+        <value>Ошибка при установке режима полезной нагрузки</value>
+    </data>
+    <data name="FlightSdrViewModel_StartRecord_Error_Sender" xml:space="preserve">
+        <value>Начать запись</value>
+    </data>
+    <data name="FlightSdrViewModel_StopRecord_Error_Sender" xml:space="preserve">
+        <value>Остановить запись</value>
+    </data>
+    <data name="RecordStartViewModel_TagName_Validation_ErrorMessage" xml:space="preserve">
+        <value>Некорректное имя тэга</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_Float64_ErrorMessage" xml:space="preserve">
+        <value>Это недопустимое значение Float64!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_Int64_ErrorMessage" xml:space="preserve">
+        <value>Это недопустимое значение Int64!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_UInt64_ErrorMessage" xml:space="preserve">
+        <value>Это недопустимое значение UInt64!</value>
+    </data>
+    <data name="RecordStartViewModel_TagValue_String8_ErrorMessage" xml:space="preserve">
+        <value>Длина строки должна быть &lt; 9 и содержать только символы ascii!</value>
+    </data>
+    <data name="RecordStartViewModel_RecordName_Validation_ErrorMessage" xml:space="preserve">
+        <value>Недопустимое имя записи</value>
+    </data>
+    <data name="RecordStartView_RecordName_Title" xml:space="preserve">
+        <value>Имя записи</value>
+    </data>
+    <data name="RecordStartView_RecordName_Watermark" xml:space="preserve">
+        <value>Введите имя для новой записи</value>
+    </data>
+    <data name="RecordStartView_AddButton_Title" xml:space="preserve">
+        <value>Добавить</value>
+    </data>
+    <data name="RecordStartView_TagName_Watermark" xml:space="preserve">
+        <value>Введите имя  для нового тэга</value>
+    </data>
+    <data name="RecordStartView_TagValue_Watermark" xml:space="preserve">
+        <value>Введите значение для нового тэга</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -137,4 +137,7 @@
     <data name="VorSdrRttViewModel_FieldStrength_Units" xml:space="preserve">
         <value>μВ/м</value>
     </data>
+    <data name="FlightSdrViewModel_Frequency_Validation_ErrorMessage" xml:space="preserve">
+        <value>Значение должно быть больше 0</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
@@ -12,8 +12,8 @@
     </Design.DataContext>
     
     <StackPanel Margin="8" Spacing="8">
-        <TextBlock Text="Record name" FontSize="20"/>
-        <TextBox Watermark="Enter new record name" Text="{Binding RecordName}"/>
+        <TextBlock Text="{x:Static sdr:RS.RecordStartView_RecordName_Title}" FontSize="20"/>
+        <TextBox Watermark="{x:Static sdr:RS.RecordStartView_RecordName_Watermark}" Text="{Binding RecordName}"/>
         <ItemsControl DockPanel.Dock="Top" ItemsSource="{Binding Tags}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
@@ -84,10 +84,10 @@
             </ItemsControl.DataTemplates>
         </ItemsControl>
         <Grid ColumnDefinitions="*, 4, 100, 4, Auto">
-            <TextBox Grid.Column="0" Watermark="Enter new tag name" Text="{Binding TagName}"/>
+            <TextBox Grid.Column="0" Watermark="{x:Static sdr:RS.RecordStartView_TagName_Watermark}" Text="{Binding TagName}"/>
             <ComboBox Grid.Column="2" Width="100" ItemsSource="{Binding Types}" SelectedItem="{Binding SelectedType}"/>
-            <Button Grid.Column="4" Content="Add" Command="{Binding AddTag}" VerticalAlignment="Top"/>
+            <Button Grid.Column="4" Content="{x:Static sdr:RS.RecordStartView_AddButton_Title}" Command="{Binding AddTag}" VerticalAlignment="Top"/>
         </Grid>
-        <TextBox Watermark="Enter new tag value" Text="{Binding TagValue}"/>
+        <TextBox Watermark="{x:Static sdr:RS.RecordStartView_TagValue_Watermark}" Text="{Binding TagValue}"/>
     </StackPanel>
 </UserControl>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartViewModel.cs
@@ -120,7 +120,7 @@ public class RecordStartViewModel : ViewModelBaseWithValidation
                     isValid = false;
                 }
                 return isValid;
-            }, _=>  "Not valid tag name" )
+            }, _ => RS.RecordStartViewModel_TagName_Validation_ErrorMessage)
             .DisposeItWith(Disposable);
 
         this.ValidationRule(x => x.TagValue, _ => CheckTagValue(_), _ => GetTagValueValidationMessage())
@@ -159,19 +159,19 @@ public class RecordStartViewModel : ViewModelBaseWithValidation
         
         if (SelectedType == "String8")
         {
-            message = "String length must be < 9, and contain only ascii-chars!";
+            message = RS.RecordStartViewModel_TagValue_String8_ErrorMessage;
         }
         else if (SelectedType == "Int64")
         {
-            message = "This is not valid Int64 value!";
+            message = RS.RecordStartViewModel_TagValue_Int64_ErrorMessage;
         }
         else if (SelectedType == "UInt64")
         {
-            message = "This is not valid UInt64 value!";
+            message = RS.RecordStartViewModel_TagValue_UInt64_ErrorMessage;
         }
         else if (SelectedType == "Float64")
         {
-            message = "This is not valid Float64 value!";
+            message = RS.RecordStartViewModel_TagValue_Float64_ErrorMessage;
         }
 
         return message;
@@ -197,7 +197,7 @@ public class RecordStartViewModel : ViewModelBaseWithValidation
                 }
                 
                 return dialog.IsPrimaryButtonEnabled;
-            }, _ =>  "Not valid record name" )
+            }, _ => RS.RecordStartViewModel_RecordName_Validation_ErrorMessage)
             .DisposeItWith(Disposable);
     }
     

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -50,7 +50,7 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
        _freqInMHzMeasureUnit = _loc.Frequency.AvailableUnits.First(_ => _.Id == Core.FrequencyUnits.MHz);
         
         Icon = MaterialIconKind.Memory;
-        Title = "Payload";
+        Title = RS.FlightSdrViewModel_Title;
         Location = WidgetLocation.Right;
 
         payload.Sdr.SupportedModes.DistinctUntilChanged()
@@ -68,21 +68,21 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
         UpdateMode = ReactiveCommand.CreateFromTask(cancel => Payload.Sdr.SetModeAndCheckResult(SelectedMode.Mode, (ulong)Math.Round(_freqInMHzMeasureUnit.ConvertToSi(FrequencyInMhz)), 1, 1, cancel));
         UpdateMode.ThrownExceptions.Subscribe(ex =>
         {
-            _logService.Error("Set mode",$"Error to set payload mode",ex); // TODO: Localize
+            _logService.Error(RS.FlightSdrViewModel_UpdateMode_Error_Sender,RS.FlightSdrViewModel_UpdateMode_Error_Message,ex);
         }).DisposeItWith(Disposable);
         
         StartRecord = ReactiveCommand.CreateFromTask(RecordStartImpl,
             this.WhenAnyValue(_=>_.IsRecordStarted).Select(_=>!_));
         StartRecord.ThrownExceptions.Subscribe(ex =>
         {
-            _logService.Error("Rec start",$"Error to set payload mode",ex);
+            _logService.Error(RS.FlightSdrViewModel_StartRecord_Error_Sender,RS.FlightSdrViewModel_StartRecord_Error_Message,ex);
         }).DisposeItWith(Disposable);
         
         StopRecord = ReactiveCommand.CreateFromTask(cancel=>Payload.Sdr.StopRecordAndCheckResult(cancel),
             this.WhenAnyValue(_=>_.IsRecordStarted));
         StopRecord.ThrownExceptions.Subscribe(ex =>
         {
-            _logService.Error("Rec stop",$"Error to set payload mode",ex);
+            _logService.Error(RS.FlightSdrViewModel_StopRecord_Error_Sender,RS.FlightSdrViewModel_StopRecord_Error_Message,ex);
         }).DisposeItWith(Disposable);
 
         Disposable.AddAction(() =>
@@ -119,10 +119,10 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
     {
         var dialog = new ContentDialog()
         {
-            Title = "New",
-            PrimaryButtonText = "Start",
+            Title = RS.FlightSdrViewModel_RecordStartDialog_Title,
+            PrimaryButtonText = RS.FlightSdrViewModel_RecordStartDialog_PrimarryButton_Name,
             IsSecondaryButtonEnabled = true,
-            SecondaryButtonText = "Cancel"
+            SecondaryButtonText = RS.FlightSdrViewModel_RecordStartDialog_SecondaryButton_Name
         };
             
         var viewModel = new RecordStartViewModel();

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -102,8 +102,16 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
             payload.Sdr.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown, cancel));
         
         this.ValidationRule(x => x.FrequencyInMhz,
-                _ => _freqInMHzMeasureUnit.IsValid(_),
-                _ => _freqInMHzMeasureUnit.GetErrorMessage(_))
+                _ =>
+                {
+                    if (double.TryParse(_, out var number))
+                    {
+                        return number > 0;
+                    }
+
+                    return false;
+                },
+                RS.FlightSdrViewModel_Frequency_Validation_ErrorMessage)
             .DisposeItWith(Disposable);
     }
     


### PR DESCRIPTION
Changed the frequency validation logic in `FlightSdrViewModel.cs` to directly validate the frequency input as a number greater than zero, instead of using _freqInMHzMeasureUnit.IsValid(_). This was done to simplify and improve the speed of validation, removing the need to convert and validate the input through the measure unit methods.

Hardcoded strings in the 'RecordStartViewModel.cs', 'RecordStartView.axaml', and 'FlightSdrViewModel.cs' files were replaced with localized resources for improving the localization support. This ensures that the respective file displays appropriate messages, placeholders, button texts etc. in different languages based on the user's locale.

Asana: https://app.asana.com/0/1203851531040615/1205134815539121/f