### PR TITLE
feat (map): change edit mode icon stroke color in MapAnchorView


### DIFF
--- a/src/Asv.Drones.Gui.Map/MapAnchorView.axaml
+++ b/src/Asv.Drones.Gui.Map/MapAnchorView.axaml
@@ -59,7 +59,7 @@
     
     <!-- Is in edit mode -->
     <Style Selector="controls|MapAnchorView:edit /template/ avalonia|MaterialIcon#PART_Icon Path">
-        <Setter Property="Stroke" Value="Red" />
+        <Setter Property="Stroke" Value="#03DAC6" />
         <Setter Property="StrokeThickness" Value="2" />
     </Style>
 


### PR DESCRIPTION
The stroke color of the edit mode icon in MapAnchorView.axaml was changed from Red to #03DAC6. This was done to improve visibility and visual consistency with the rest of the application's color scheme.

Asana: https://app.asana.com/0/1203851531040615/1205044869965329/f