### PR TITLE
feat (core): update measure unit descriptions for localization

### DIFF
--- a/src/Asv.Drones.Gui.Core/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Core/RS.Designer.cs
@@ -123,6 +123,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Altitude measure units.
+        /// </summary>
+        public static string Altitude_Description {
+            get {
+                return ResourceManager.GetString("Altitude_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Feets.
         /// </summary>
         public static string Altitude_Feet_Title {
@@ -159,6 +168,24 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Altitude.
+        /// </summary>
+        public static string Altitude_Title {
+            get {
+                return ResourceManager.GetString("Altitude_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Amplitude modulation measure units.
+        /// </summary>
+        public static string AmplitudeModulation_Description {
+            get {
+                return ResourceManager.GetString("AmplitudeModulation_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In parts.
         /// </summary>
         public static string AmplitudeModulation_InParts_Unit {
@@ -177,11 +204,38 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AM.
+        /// </summary>
+        public static string AmplitudeModulation_Title {
+            get {
+                return ResourceManager.GetString("AmplitudeModulation_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Move anchors.
         /// </summary>
         public static string AnchorMoverActionView_Title {
             get {
                 return ResourceManager.GetString("AnchorMoverActionView_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bearing measure units.
+        /// </summary>
+        public static string Bearing_Description {
+            get {
+                return ResourceManager.GetString("Bearing_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bearing.
+        /// </summary>
+        public static string Bearing_Title {
+            get {
+                return ResourceManager.GetString("Bearing_Title", resourceCulture);
             }
         }
         
@@ -555,6 +609,42 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Difference depth of modulation measure units.
+        /// </summary>
+        public static string DdmGp_Description {
+            get {
+                return ResourceManager.GetString("DdmGp_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DDM (Gp).
+        /// </summary>
+        public static string DdmGp_Title {
+            get {
+                return ResourceManager.GetString("DdmGp_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Difference depth of modulation measure units.
+        /// </summary>
+        public static string DdmLlz_Description {
+            get {
+                return ResourceManager.GetString("DdmLlz_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DDM (Llz).
+        /// </summary>
+        public static string DdmLlz_Title {
+            get {
+                return ResourceManager.GetString("DdmLlz_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Deg]°.
         /// </summary>
         public static string Degrees_Degree_Title {
@@ -564,11 +654,29 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Angle measure units.
+        /// </summary>
+        public static string Degrees_Description {
+            get {
+                return ResourceManager.GetString("Degrees_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Deg]°[Min]′[Sec]′′.
         /// </summary>
         public static string Degrees_DMS_Title {
             get {
                 return ResourceManager.GetString("Degrees_DMS_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Angle.
+        /// </summary>
+        public static string Degrees_Title {
+            get {
+                return ResourceManager.GetString("Degrees_Title", resourceCulture);
             }
         }
         
@@ -587,6 +695,15 @@ namespace Asv.Drones.Gui.Core {
         public static string DeviceBrowserView_Header {
             get {
                 return ResourceManager.GetString("DeviceBrowserView_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Distance measure units.
+        /// </summary>
+        public static string Distance_Description {
+            get {
+                return ResourceManager.GetString("Distance_Description", resourceCulture);
             }
         }
         
@@ -627,11 +744,29 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Distance.
+        /// </summary>
+        public static string Distance_Title {
+            get {
+                return ResourceManager.GetString("Distance_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Flight mode.
         /// </summary>
         public static string FlightShellMenuItem_Name {
             get {
                 return ResourceManager.GetString("FlightShellMenuItem_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Frequency measure units.
+        /// </summary>
+        public static string Frequency_Description {
+            get {
+                return ResourceManager.GetString("Frequency_Description", resourceCulture);
             }
         }
         
@@ -708,6 +843,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Frequency.
+        /// </summary>
+        public static string Frequency_Title {
+            get {
+                return ResourceManager.GetString("Frequency_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open store file.
         /// </summary>
         public static string GlobalCommands_OpenStoreDialogTitle {
@@ -780,11 +924,29 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Latitude measure units.
+        /// </summary>
+        public static string Latitude_Description {
+            get {
+                return ResourceManager.GetString("Latitude_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Deg]°[Min]′[Sec]′′.
         /// </summary>
         public static string Latitude_DMS_Title {
             get {
                 return ResourceManager.GetString("Latitude_DMS_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Latitude.
+        /// </summary>
+        public static string Latitude_Title {
+            get {
+                return ResourceManager.GetString("Latitude_Title", resourceCulture);
             }
         }
         
@@ -1005,11 +1167,29 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Longitude measure units.
+        /// </summary>
+        public static string Longitude_Description {
+            get {
+                return ResourceManager.GetString("Longitude_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Deg]°[Min]′[Sec]′′.
         /// </summary>
         public static string Longitude_DMS_Title {
             get {
                 return ResourceManager.GetString("Longitude_DMS_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Longitude.
+        /// </summary>
+        public static string Longitude_Title {
+            get {
+                return ResourceManager.GetString("Longitude_Title", resourceCulture);
             }
         }
         
@@ -1127,6 +1307,42 @@ namespace Asv.Drones.Gui.Core {
         public static string MavlinkDeviceView_Status_Name {
             get {
                 return ResourceManager.GetString("MavlinkDeviceView_Status_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value must be a number.
+        /// </summary>
+        public static string MeasureUnitBase_ErrorMessage_NotANumber {
+            get {
+                return ResourceManager.GetString("MeasureUnitBase_ErrorMessage_NotANumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value can&apos;t be null or white space.
+        /// </summary>
+        public static string MeasureUnitBase_ErrorMessage_NullOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("MeasureUnitBase_ErrorMessage_NullOrWhiteSpace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value must be greater than {0} ({1}).
+        /// </summary>
+        public static string MeasureUnitExtensions_ErrorMessage_GreaterValue {
+            get {
+                return ResourceManager.GetString("MeasureUnitExtensions_ErrorMessage_GreaterValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value must be less than {0} ({1}).
+        /// </summary>
+        public static string MeasureUnitExtensions_ErrorMessage_LesserValue {
+            get {
+                return ResourceManager.GetString("MeasureUnitExtensions_ErrorMessage_LesserValue", resourceCulture);
             }
         }
         
@@ -1446,6 +1662,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Phase measure units.
+        /// </summary>
+        public static string Phase_Description {
+            get {
+                return ResourceManager.GetString("Phase_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Radian.
         /// </summary>
         public static string Phase_Radian_Title {
@@ -1460,6 +1685,15 @@ namespace Asv.Drones.Gui.Core {
         public static string Phase_Radian_Unit {
             get {
                 return ResourceManager.GetString("Phase_Radian_Unit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Phase.
+        /// </summary>
+        public static string Phase_Title {
+            get {
+                return ResourceManager.GetString("Phase_Title", resourceCulture);
             }
         }
         
@@ -1514,6 +1748,24 @@ namespace Asv.Drones.Gui.Core {
         public static string Power_Dbm_Unit {
             get {
                 return ResourceManager.GetString("Power_Dbm_Unit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Power measure units.
+        /// </summary>
+        public static string Power_Description {
+            get {
+                return ResourceManager.GetString("Power_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Power.
+        /// </summary>
+        public static string Power_Title {
+            get {
+                return ResourceManager.GetString("Power_Title", resourceCulture);
             }
         }
         
@@ -1676,6 +1928,24 @@ namespace Asv.Drones.Gui.Core {
         public static string SavedCoordsViewModel_RemoveItem_Title {
             get {
                 return ResourceManager.GetString("SavedCoordsViewModel_RemoveItem_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SDM.
+        /// </summary>
+        public static string Sdm_Description {
+            get {
+                return ResourceManager.GetString("Sdm_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sum depth of modulation measure units.
+        /// </summary>
+        public static string Sdm_Title {
+            get {
+                return ResourceManager.GetString("Sdm_Title", resourceCulture);
             }
         }
         
@@ -1923,6 +2193,42 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Value must be a number.
+        /// </summary>
+        public static string TemperatureCelsius_ErrorMessage_NaN {
+            get {
+                return ResourceManager.GetString("TemperatureCelsius_ErrorMessage_NaN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value can&apos;t be null or white space.
+        /// </summary>
+        public static string TemperatureCelsius_ErrorMessage_NullOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("TemperatureCelsius_ErrorMessage_NullOrWhiteSpace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value must be a number.
+        /// </summary>
+        public static string TemperatureFarenheit_ErrorMessage_NaN {
+            get {
+                return ResourceManager.GetString("TemperatureFarenheit_ErrorMessage_NaN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value can&apos;t be null or white space.
+        /// </summary>
+        public static string TemperatureFarenheit_ErrorMessage_NullOrWhiteSpace {
+            get {
+                return ResourceManager.GetString("TemperatureFarenheit_ErrorMessage_NullOrWhiteSpace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to LeftToRight.
         /// </summary>
         public static string ThemeService_FlowDirections_LeftToRight {
@@ -2076,6 +2382,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Velocity measure units.
+        /// </summary>
+        public static string Velocity_Description {
+            get {
+                return ResourceManager.GetString("Velocity_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to km/h.
         /// </summary>
         public static string Velocity_KilometersPerHourUnit {
@@ -2099,6 +2414,15 @@ namespace Asv.Drones.Gui.Core {
         public static string Velocity_MilesPerHourUnit {
             get {
                 return ResourceManager.GetString("Velocity_MilesPerHourUnit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Velocity.
+        /// </summary>
+        public static string Velocity_Title {
+            get {
+                return ResourceManager.GetString("Velocity_Title", resourceCulture);
             }
         }
         

--- a/src/Asv.Drones.Gui.Core/RS.resx
+++ b/src/Asv.Drones.Gui.Core/RS.resx
@@ -806,4 +806,112 @@
   <data name="Longitude_DMS_Title" xml:space="preserve">
     <value>[Deg]°[Min]′[Sec]′′</value>
   </data>
+  <data name="MeasureUnitExtensions_ErrorMessage_GreaterValue" xml:space="preserve">
+    <value>Value must be greater than {0} ({1})</value>
+  </data>
+  <data name="MeasureUnitExtensions_ErrorMessage_LesserValue" xml:space="preserve">
+    <value>Value must be less than {0} ({1})</value>
+  </data>
+  <data name="Altitude_Title" xml:space="preserve">
+    <value>Altitude</value>
+  </data>
+  <data name="Altitude_Description" xml:space="preserve">
+    <value>Altitude measure units</value>
+  </data>
+  <data name="AmplitudeModulation_Title" xml:space="preserve">
+    <value>AM</value>
+  </data>
+  <data name="AmplitudeModulation_Description" xml:space="preserve">
+    <value>Amplitude modulation measure units</value>
+  </data>
+  <data name="Bearing_Title" xml:space="preserve">
+    <value>Bearing</value>
+  </data>
+  <data name="Bearing_Description" xml:space="preserve">
+    <value>Bearing measure units</value>
+  </data>
+  <data name="Degrees_Title" xml:space="preserve">
+    <value>Angle</value>
+  </data>
+  <data name="Degrees_Description" xml:space="preserve">
+    <value>Angle measure units</value>
+  </data>
+  <data name="Distance_Title" xml:space="preserve">
+    <value>Distance</value>
+  </data>
+  <data name="Distance_Description" xml:space="preserve">
+    <value>Distance measure units</value>
+  </data>
+  <data name="Frequency_Title" xml:space="preserve">
+    <value>Frequency</value>
+  </data>
+  <data name="Frequency_Description" xml:space="preserve">
+    <value>Frequency measure units</value>
+  </data>
+  <data name="Latitude_Title" xml:space="preserve">
+    <value>Latitude</value>
+  </data>
+  <data name="Latitude_Description" xml:space="preserve">
+    <value>Latitude measure units</value>
+  </data>
+  <data name="Longitude_Title" xml:space="preserve">
+    <value>Longitude</value>
+  </data>
+  <data name="Longitude_Description" xml:space="preserve">
+    <value>Longitude measure units</value>
+  </data>
+  <data name="MeasureUnitBase_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+    <value>Value can't be null or white space</value>
+  </data>
+  <data name="MeasureUnitBase_ErrorMessage_NotANumber" xml:space="preserve">
+    <value>Value must be a number</value>
+  </data>
+  <data name="Phase_Title" xml:space="preserve">
+    <value>Phase</value>
+  </data>
+  <data name="Phase_Description" xml:space="preserve">
+    <value>Phase measure units</value>
+  </data>
+  <data name="Power_Title" xml:space="preserve">
+    <value>Power</value>
+  </data>
+  <data name="Power_Description" xml:space="preserve">
+    <value>Power measure units</value>
+  </data>
+  <data name="TemperatureCelsius_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+    <value>Value can't be null or white space</value>
+  </data>
+  <data name="TemperatureCelsius_ErrorMessage_NaN" xml:space="preserve">
+    <value>Value must be a number</value>
+  </data>
+  <data name="TemperatureFarenheit_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+    <value>Value can't be null or white space</value>
+  </data>
+  <data name="TemperatureFarenheit_ErrorMessage_NaN" xml:space="preserve">
+    <value>Value must be a number</value>
+  </data>
+  <data name="Velocity_Title" xml:space="preserve">
+    <value>Velocity</value>
+  </data>
+  <data name="Velocity_Description" xml:space="preserve">
+    <value>Velocity measure units</value>
+  </data>
+  <data name="DdmGp_Title" xml:space="preserve">
+    <value>DDM (Gp)</value>
+  </data>
+  <data name="DdmGp_Description" xml:space="preserve">
+    <value>Difference depth of modulation measure units</value>
+  </data>
+  <data name="DdmLlz_Title" xml:space="preserve">
+    <value>DDM (Llz)</value>
+  </data>
+  <data name="DdmLlz_Description" xml:space="preserve">
+    <value>Difference depth of modulation measure units</value>
+  </data>
+  <data name="Sdm_Title" xml:space="preserve">
+    <value>Sum depth of modulation measure units</value>
+  </data>
+  <data name="Sdm_Description" xml:space="preserve">
+    <value>SDM</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Core/RS.ru.resx
@@ -829,4 +829,112 @@
   <data name="Longitude_Degree_Title" xml:space="preserve">
 	  <value>[Град]°</value>
   </data>
+  <data name="MeasureUnitExtensions_ErrorMessage_GreaterValue" xml:space="preserve">
+	  <value>Значение должно быть больше чем {0} ({1})</value>
+  </data>
+  <data name="MeasureUnitExtensions_ErrorMessage_LesserValue" xml:space="preserve">
+	  <value>Значение должно быть меньше чем {0} ({1})</value>
+  </data>
+  <data name="Altitude_Description" xml:space="preserve">
+	  <value>Единицы измерения высоты</value>
+  </data>
+  <data name="Altitude_Title" xml:space="preserve">
+	  <value>Высота</value>
+  </data>
+  <data name="AmplitudeModulation_Description" xml:space="preserve">
+	  <value>Единицы измерения амплитудной модуляции</value>
+  </data>
+  <data name="AmplitudeModulation_Title" xml:space="preserve">
+	  <value>АМ</value>
+  </data>
+  <data name="Bearing_Description" xml:space="preserve">
+	  <value>Единицы измерения несущей</value>
+  </data>
+  <data name="Bearing_Title" xml:space="preserve">
+	  <value>Несущая</value>
+  </data>
+  <data name="Degrees_Description" xml:space="preserve">
+	  <value>Единицы  измерения угла</value>
+  </data>
+  <data name="Degrees_Title" xml:space="preserve">
+	  <value>Угол</value>
+  </data>
+  <data name="Distance_Description" xml:space="preserve">
+	  <value>Единицы измерения расстояния</value>
+  </data>
+  <data name="Distance_Title" xml:space="preserve">
+	  <value>Расстояние</value>
+  </data>
+  <data name="Frequency_Title" xml:space="preserve">
+	  <value>Частота</value>
+  </data>
+  <data name="Frequency_Description" xml:space="preserve">
+	  <value>Единицы измерения частоты</value>
+  </data>
+  <data name="Latitude_Description" xml:space="preserve">
+	  <value>Единицы измерения широты</value>
+  </data>
+  <data name="Latitude_Title" xml:space="preserve">
+	  <value>Широта</value>
+  </data>
+  <data name="Longitude_Description" xml:space="preserve">
+	  <value>Единицы измерения долготы</value>
+  </data>
+  <data name="Longitude_Title" xml:space="preserve">
+	  <value>Долгота</value>
+  </data>
+  <data name="MeasureUnitBase_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+	  <value>Значение не должно быть пустым или пробелом</value>
+  </data>
+  <data name="MeasureUnitBase_ErrorMessage_NotANumber" xml:space="preserve">
+	  <value>Значение должно быть числом</value>
+  </data>
+  <data name="Phase_Description" xml:space="preserve">
+	  <value>Единицы измерения фазы</value>
+  </data>
+  <data name="Phase_Title" xml:space="preserve">
+	  <value>Фаза</value>
+  </data>
+  <data name="Power_Description" xml:space="preserve">
+	  <value>Единицы измерения мощности</value>
+  </data>
+  <data name="Power_Title" xml:space="preserve">
+	  <value>Мощность</value>
+  </data>
+  <data name="TemperatureCelsius_ErrorMessage_NaN" xml:space="preserve">
+	  <value>Значение должно быть числом</value>
+  </data>
+  <data name="TemperatureFarenheit_ErrorMessage_NaN" xml:space="preserve">
+	  <value>Значение должно быть числом</value>
+  </data>
+  <data name="TemperatureCelsius_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+	  <value>Значение не должно быть пустым или пробелом</value>
+  </data>
+  <data name="TemperatureFarenheit_ErrorMessage_NullOrWhiteSpace" xml:space="preserve">
+	  <value>Значение не должно быть пустым или пробелом</value>
+  </data>
+  <data name="Velocity_Description" xml:space="preserve">
+	  <value>Единицы измерения скорости</value>
+  </data>
+  <data name="Velocity_Title" xml:space="preserve">
+	  <value>Скорость</value>
+  </data>
+  <data name="DdmGp_Title" xml:space="preserve">
+	  <value>РГМ (Gp)</value>
+  </data>
+  <data name="DdmGp_Description" xml:space="preserve">
+	  <value>Единицы измереня разницы в глубине модуляции</value>
+  </data>
+  <data name="DdmLlz_Title" xml:space="preserve">
+	  <value>РГМ (Llz)</value>
+  </data>
+  <data name="DdmLlz_Description" xml:space="preserve">
+	  <value>Единицы измереня разницы в глубине модуляции</value>
+  </data>
+  <data name="Sdm_Description" xml:space="preserve">
+	  <value>СГМ</value>
+  </data>
+  <data name="Sdm_Title" xml:space="preserve">
+	  <value>Единицы измерения суммы глубины модуляции</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Altitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Altitude.cs
@@ -22,6 +22,6 @@ public class Altitude : MeasureUnitBase<double,AltitudeUnits>
         
     }
 
-    public override string Title => "Altitude";
-    public override string Description => "Units of measure for the altitude";
+    public override string Title => RS.Altitude_Title;
+    public override string Description => RS.Altitude_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/AmplitudeModulation.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/AmplitudeModulation.cs
@@ -20,7 +20,7 @@ public class AmplitudeModulation : MeasureUnitBase<double,AmplitudeModulationUni
     {
     }
 
-    public override string Title => "AM";
+    public override string Title => RS.AmplitudeModulation_Title;
 
-    public override string Description => "Units of measure for amplitude modulation";
+    public override string Description => RS.AmplitudeModulation_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Bearing.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Bearing.cs
@@ -16,7 +16,7 @@ public class Bearing : MeasureUnitBase<double,BearingUnits>
     {
     }
 
-    public override string Title => "Bearing";
+    public override string Title => RS.Bearing_Title;
 
-    public override string Description => "Units of measure for bearing";
+    public override string Description => RS.Bearing_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/DdmGp.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/DdmGp.cs
@@ -19,7 +19,7 @@ public class DdmGp : MeasureUnitBase<double,DdmUnits>
     {
     }
 
-    public override string Title => "DDM (Gp)";
+    public override string Title => RS.DdmGp_Title;
 
-    public override string Description => "Units of measure for difference in the depth of modulation";
+    public override string Description => RS.DdmGp_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/DdmLlz.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/DdmLlz.cs
@@ -29,9 +29,9 @@ public class DdmLlz : MeasureUnitBase<double,DdmUnits>
     {
     }
 
-    public override string Title => "DDM (Llz)";
+    public override string Title => RS.DdmLlz_Title;
 
-    public override string Description => "Units of measure for difference in the depth of modulation";
+    public override string Description => RS.DdmLlz_Description;
 }
 
 public class DdmLlzInParts : IMeasureUnitItem<double, DdmUnits>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Degrees.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Degrees.cs
@@ -20,8 +20,8 @@ public class Degrees : MeasureUnitBase<double, DegreeUnits>
     {
     }
 
-    public override string Title => "Angle";
-    public override string Description => "Units of measure for the angle";
+    public override string Title => RS.Degrees_Title;
+    public override string Description => RS.Degrees_Description;
 }
 
 public class DmsMeasureUnit : IMeasureUnitItem<double, DegreeUnits>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Distance.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Distance.cs
@@ -18,7 +18,7 @@ public class Distance : MeasureUnitBase<double,DistanceUnits>
     {
         
     }
-    public override string Title => "Distance";
-    public override string Description => "Units of measure for distance";
+    public override string Title => RS.Distance_Title;
+    public override string Description => RS.Distance_Description;
 
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Frequency.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Frequency.cs
@@ -26,7 +26,7 @@ public class Frequency : MeasureUnitBase<double,FrequencyUnits>
     {
     }
 
-    public override string Title => "Frequency";
+    public override string Title => RS.Frequency_Title;
 
-    public override string Description => "Units of measure for Frequency";
+    public override string Description => RS.Frequency_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/IMeasureUnit.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/IMeasureUnit.cs
@@ -72,8 +72,8 @@ namespace Asv.Drones.Gui.Core
            var msg = src.CurrentUnit.Value.GetErrorMessage(value);
            if (msg.IsNullOrWhiteSpace() == false) return msg;
            var siValue = src.CurrentUnit.Value.ConvertToSi(value);
-           if ( siValue< minSiValue) return $"Value must be greater than {src.CurrentUnit.Value.FromSiToStringWithUnits(minSiValue)} ({src.SiUnit.FromSiToStringWithUnits(siValue)})"; // TODO: Localize
-           if ( siValue> maxSiValue) return $"Value must be less than {src.CurrentUnit.Value.FromSiToStringWithUnits(minSiValue)} {src.SiUnit.FromSiToStringWithUnits(siValue)}"; // TODO: Localize
+           if ( siValue< minSiValue) return string.Format(RS.MeasureUnitExtensions_ErrorMessage_GreaterValue, src.CurrentUnit.Value.FromSiToStringWithUnits(minSiValue), src.SiUnit.FromSiToStringWithUnits(siValue));
+           if (siValue > maxSiValue) return string.Format(RS.MeasureUnitExtensions_ErrorMessage_LesserValue, src.CurrentUnit.Value.FromSiToStringWithUnits(minSiValue), src.SiUnit.FromSiToStringWithUnits(siValue));
            return null;
        }
 

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Latitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Latitude.cs
@@ -20,8 +20,8 @@ public class Latitude : MeasureUnitBase<double,LatitudeUnits>
         
     }
 
-    public override string Title => "Latitude";
-    public override string Description => "Units of latitude";
+    public override string Title => RS.Latitude_Title;
+    public override string Description => RS.Latitude_Description;
 }
 
 public class LatitudeUnitDeg : IMeasureUnitItem<double, LatitudeUnits>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Longitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Longitude.cs
@@ -19,8 +19,8 @@ public class Longitude : MeasureUnitBase<double,LongitudeUnits>
         
     }
 
-    public override string Title => "Longitude";
-    public override string Description => "Units of longitude";
+    public override string Title => RS.Longitude_Title;
+    public override string Description => RS.Longitude_Description;
 }
 
 public class LongitudeUnitDeg :  IMeasureUnitItem<double, LongitudeUnits>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/MeasureUnitBase.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/MeasureUnitBase.cs
@@ -84,9 +84,9 @@ public class DoubleMeasureUnitItem<TEnum> : IMeasureUnitItem<double, TEnum>
 
     public virtual string? GetErrorMessage(string value)
     {
-        if (value.IsNullOrWhiteSpace()) return "Value can't be null or white space"; // TODO: Localize
+        if (value.IsNullOrWhiteSpace()) return RS.MeasureUnitBase_ErrorMessage_NullOrWhiteSpace;
         value = value.Replace(',', '.');
-        return double.TryParse(value,NumberStyles.Any,CultureInfo.InvariantCulture, out _) == false ? "Value must be a number" : null;
+        return double.TryParse(value,NumberStyles.Any,CultureInfo.InvariantCulture, out _) == false ? RS.MeasureUnitBase_ErrorMessage_NotANumber : null;
     }
 
     

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Phase.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Phase.cs
@@ -20,7 +20,7 @@ public class Phase : MeasureUnitBase<double,PhaseUnits>
     {
     }
 
-    public override string Title => "Phase";
+    public override string Title => RS.Phase_Title;
 
-    public override string Description => "Units of measure for phase";
+    public override string Description => RS.Phase_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Power.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Power.cs
@@ -16,7 +16,7 @@ public class Power : MeasureUnitBase<double,PowerUnits>
     {
     }
 
-    public override string Title => "Power";
+    public override string Title => RS.Power_Title;
 
-    public override string Description => "Units of measure for power";
+    public override string Description => RS.Power_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Sdm.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Sdm.cs
@@ -20,7 +20,7 @@ public class Sdm : MeasureUnitBase<double,SdmUnits>
     {
     }
 
-    public override string Title => "SDM";
+    public override string Title => RS.Sdm_Title;
 
-    public override string Description => "Units of measure for sum depth of modulation";
+    public override string Description => RS.Sdm_Description;
 }

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Temperature.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Temperature.cs
@@ -54,10 +54,10 @@ public class TemperatureCelsius : IMeasureUnitItem<double, TemperatureUnits>
 
     public string GetErrorMessage(string value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return "Value can't be null or white space"; // TODO: Localize
+        if (string.IsNullOrWhiteSpace(value)) return RS.TemperatureCelsius_ErrorMessage_NullOrWhiteSpace;
         value = value.Replace(',', '.');
         if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var v) == false)
-            return "Value must be a number";
+            return RS.TemperatureCelsius_ErrorMessage_NaN;
         return null;
     }
 
@@ -110,10 +110,10 @@ public class TemperatureFarenheit : IMeasureUnitItem<double, TemperatureUnits>
 
     public string GetErrorMessage(string value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return "Value can't be null or white space"; // TODO: Localize
+        if (string.IsNullOrWhiteSpace(value)) return RS.TemperatureFarenheit_ErrorMessage_NullOrWhiteSpace;
         value = value.Replace(',', '.');
         if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var v) == false)
-            return "Value must be a number";
+            return RS.TemperatureFarenheit_ErrorMessage_NaN;
         return null;
     }
 

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Velocity.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Velocity.cs
@@ -26,8 +26,8 @@ public class Velocity : MeasureUnitBase<double,VelocityUnits>
         
     }
 
-    public override string Title => "Velocity";
-    public override string Description => "Units of measure for speed";
+    public override string Title => RS.Velocity_Title;
+    public override string Description => RS.Velocity_Description;
     
     
 }


### PR DESCRIPTION
In this commit, we replaced the hardcoded string descriptions for various measure units with their respective localized equivalents from the resources file (RS). This change was necessary for multi-language support. Ensuring these descriptions are localized ensures the application's UI is accurately and appropriately presented for users in different locales.

Asana: https://app.asana.com/0/1203851531040615/1205157700476802/f