### PR TITLE
feat: add AnchorsEditor in map widgets

### DIFF
--- a/src/Asv.Drones.Gui.Core/Asv.Drones.Gui.Core.csproj.DotSettings
+++ b/src/Asv.Drones.Gui.Core/Asv.Drones.Gui.Core.csproj.DotSettings
@@ -40,6 +40,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cmap_005Cplaning_005Cwidgets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cmap_005Cplaning/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cmap_005Cruler/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cmap_005Cwidgets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cpacketviewer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cpacketviewer_005Cconverters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cplaning/@EntryIndexedValue">True</s:Boolean>

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningWidgetBase.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningWidgetBase.cs
@@ -1,6 +1,6 @@
 namespace Asv.Drones.Gui.Core
 {
-    public abstract class PlaningWidgetBase:MapWidgetBase
+    public abstract class PlaningWidgetBase : MapWidgetBase
     {
         public const string UriString = PlaningPageViewModel.UriString + ".widget";
         public static readonly Uri Uri = new(UriString);

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml
@@ -1,0 +1,53 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:core="clr-namespace:Asv.Drones.Gui.Core"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             mc:Ignorable="d"
+             d:DesignWidth="240"
+             x:Class="Asv.Drones.Gui.Core.AnchorsEditorView"
+             x:DataType="core:AnchorsEditorViewModel"
+             IsVisible="{CompiledBinding IsVisible}">
+    <Design.DataContext>
+        <core:AnchorsEditorViewModel/>
+    </Design.DataContext>
+    <Border Background="{DynamicResource SolidBackgroundFillColorBase}" Opacity="0.8" CornerRadius="{DynamicResource ControlCornerRadius}" ClipToBounds="True">
+        <StackPanel Margin="10" Spacing="8">
+            <StackPanel Margin="0 0 0 10" Orientation="Horizontal" Spacing="8">
+                <avalonia:MaterialIcon Kind="{CompiledBinding Icon}"/>
+                <TextBlock Text="{CompiledBinding Title}"/>
+            </StackPanel>
+            <Grid ColumnDefinitions="*, 15, 3*">
+                <TextBlock Text="Latitude" TextWrapping="NoWrap" Grid.Column="0"/>
+                <TextBox Text="{CompiledBinding Latitude}" Grid.Column="2" 
+                         IsReadOnly="{CompiledBinding IsInEditMode}" 
+                         IsEnabled="{CompiledBinding IsEditable}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Text="{CompiledBinding LatitudeUnits}" VerticalAlignment="Center" Margin="8 4"/>
+                    </TextBox.InnerRightContent>
+                </TextBox>
+            </Grid>
+            <Grid ColumnDefinitions="*, 15, 3*">
+                <TextBlock Text="Longitude" Grid.Column="0"/>
+                <TextBox Text="{CompiledBinding Longitude}" Grid.Column="2" 
+                         IsReadOnly="{CompiledBinding IsInEditMode}" 
+                         IsEnabled="{CompiledBinding IsEditable}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Text="{CompiledBinding LongitudeUnits}" VerticalAlignment="Center" Margin="8 4"/>
+                    </TextBox.InnerRightContent>
+                </TextBox>
+            </Grid>
+            <Grid ColumnDefinitions="*, 15, 3*">
+                <TextBlock Text="Altitude" Grid.Column="0"/>
+                <TextBox Text="{CompiledBinding Altitude}" Grid.Column="2" 
+                         IsReadOnly="{CompiledBinding IsInEditMode}" 
+                         IsEnabled="{CompiledBinding IsEditable}">
+                    <TextBox.InnerRightContent>
+                        <TextBlock Text="{CompiledBinding AltitudeUnits}" VerticalAlignment="Center" Margin="8 4"/>
+                    </TextBox.InnerRightContent>
+                </TextBox>
+            </Grid>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.Composition;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
+
+namespace Asv.Drones.Gui.Core;
+
+[ExportView(typeof(AnchorsEditorViewModel))]
+[PartCreationPolicy(CreationPolicy.NonShared)]
+public partial class AnchorsEditorView : ReactiveUserControl<AnchorsEditorViewModel>
+{
+    public AnchorsEditorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorViewModel.cs
@@ -1,0 +1,167 @@
+﻿using System.ComponentModel.Composition;
+using System.Reactive.Linq;
+using Asv.Common;
+using DynamicData.Binding;
+using Material.Icons;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using ReactiveUI.Validation.Extensions;
+
+namespace Asv.Drones.Gui.Core;
+
+public class AnchorsEditorViewModel : MapWidgetBase
+{
+    private readonly ILocalizationService _loc;
+    
+    public const string UriString = "asv:shell.page.map.anchors-editor";
+    
+    public AnchorsEditorViewModel() : base(new Uri(UriString))
+    {
+        
+    }
+
+    [ImportingConstructor]
+    public AnchorsEditorViewModel(ILocalizationService loc) : this()
+    {
+        _loc = loc;
+    }
+    
+    [Reactive]
+    public bool IsEditable { get; set; }
+    
+    [Reactive]
+    public bool IsInEditMode { get; set; }
+    
+    [Reactive]
+    public bool IsVisible { get; set; }
+    
+    [Reactive]
+    public string Latitude { get; set; }
+    
+    [Reactive]
+    public string LatitudeUnits { get; set; }
+    
+    [Reactive]
+    public string Longitude { get; set; }
+    
+    [Reactive]
+    public string LongitudeUnits { get; set; }
+
+    [Reactive]
+    public string Altitude { get; set; }
+    
+    [Reactive]
+    public string AltitudeUnits { get; set; }
+
+    protected override void InternalAfterMapInit(IMap context)
+    {
+        context.WhenAnyValue(_ => _.SelectedItem)
+            .Subscribe(_ =>
+            {
+                if (_ != null)
+                {
+                    IsVisible = true;
+                    
+                    _.WhenAnyValue(_ => _.Location)
+                        .Subscribe(_ =>
+                        {
+                            Latitude = _loc.Latitude.FromSiToString(_.Latitude);
+                            Longitude = _loc.Longitude.FromSiToString(_.Longitude);
+                            Altitude = _loc.Altitude.FromSiToString(_.Altitude);
+                            
+                            LatitudeUnits = _loc.Latitude.CurrentUnit.Value.Unit;
+                            LongitudeUnits = _loc.Longitude.CurrentUnit.Value.Unit;
+                            AltitudeUnits = _loc.Altitude.CurrentUnit.Value.Unit;
+                        })
+                        .DisposeItWith(Disposable);
+        
+                    _.WhenAnyValue(_ => _.Icon)
+                        .Subscribe(_ =>
+                        {
+                            Icon = _;
+                        })
+                        .DisposeItWith(Disposable);
+        
+                    _.WhenAnyValue(_ => _.Title)
+                        .Subscribe(_ =>
+                        {
+                            Title = _;
+                        })
+                        .DisposeItWith(Disposable);
+        
+                    _.WhenAnyValue(_ => _.IsEditable)
+                        .Subscribe(_ =>
+                        {
+                            IsEditable = _;
+                        })
+                        .DisposeItWith(Disposable);
+        
+                    _.WhenAnyValue(_ => _.IsInEditMode)
+                        .Subscribe(_ =>
+                        {
+                            IsInEditMode = _;
+                        })
+                        .DisposeItWith(Disposable);
+                }
+                else
+                {
+                    IsVisible = false;
+                }
+            })
+            .DisposeItWith(Disposable);
+        
+        this.WhenPropertyChanged(_ => _.Latitude, false)
+            .Subscribe(_ =>
+            {
+                if (context.SelectedItem != null && !string.IsNullOrWhiteSpace(_.Value) && 
+                    _loc.Latitude.IsValid(_.Value) && IsInEditMode)
+                {
+                    var prevLocation = context.SelectedItem.Location;
+                    context.SelectedItem.Location = new GeoPoint(_loc.Latitude.CurrentUnit.Value.ConvertToSi(_.Value),
+                        prevLocation.Longitude, prevLocation.Altitude);
+                }
+            })
+            .DisposeItWith(Disposable);
+        
+        this.WhenPropertyChanged(_ => _.Longitude, false)
+            .Subscribe(_ =>
+            {
+                if (context.SelectedItem != null && !string.IsNullOrWhiteSpace(_.Value)&& 
+                    _loc.Longitude.IsValid(_.Value) && IsInEditMode)
+                {
+                    var prevLocation = context.SelectedItem.Location;
+                    context.SelectedItem.Location = new GeoPoint(prevLocation.Latitude,
+                        _loc.Longitude.CurrentUnit.Value.ConvertToSi(_.Value), prevLocation.Altitude);
+                }
+            })
+            .DisposeItWith(Disposable);
+        
+        this.WhenPropertyChanged(_ => _.Altitude, false)
+            .Subscribe(_ =>
+            {
+                if (context.SelectedItem != null && !string.IsNullOrWhiteSpace(_.Value) && 
+                    _loc.Altitude.IsValid(_.Value) && IsInEditMode)
+                {
+                    var prevLocation = context.SelectedItem.Location;
+                    context.SelectedItem.Location = new GeoPoint(prevLocation.Latitude,
+                        prevLocation.Longitude, _loc.Altitude.CurrentUnit.Value.ConvertToSi(_.Value));
+                }
+            })
+            .DisposeItWith(Disposable);
+        
+        this.ValidationRule(x => x.Latitude,
+                _ => _loc.Latitude.IsValid(_),
+                _ => _loc.Latitude.GetErrorMessage(_))
+            .DisposeItWith(Disposable);
+        
+        this.ValidationRule(x => x.Longitude,
+                _ => _loc.Longitude.IsValid(_),
+                _ => _loc.Longitude.GetErrorMessage(_))
+            .DisposeItWith(Disposable);
+        
+        this.ValidationRule(x => x.Altitude,
+                _ => _loc.Altitude.IsValid(_),
+                _ => _loc.Altitude.GetErrorMessage(_))
+            .DisposeItWith(Disposable);
+    }
+}

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorWidgetProvider.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorWidgetProvider.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.Composition;
+using DynamicData;
+
+namespace Asv.Drones.Gui.Core;
+
+[Export(FlightPageViewModel.UriString, typeof(IViewModelProvider<IMapWidget>))]
+[Export(PlaningPageViewModel.UriString, typeof(IViewModelProvider<IMapWidget>))]
+[PartCreationPolicy(CreationPolicy.NonShared)]
+public class AnchorsEditorWidgetProvider : ViewModelProviderBase<IMapWidget>
+{
+    [ImportingConstructor]
+    public AnchorsEditorWidgetProvider(ILocalizationService loc)
+    {
+        Source.AddOrUpdate(new AnchorsEditorViewModel(loc));
+    }
+}


### PR DESCRIPTION
AnchorsEditor has been added to the map widgets. This editor allows users to edit geo-location, represented by latitude, longitude, and altitude, of selected map items. This change enhances the user experience by providing an intuitive UI to alter the geo-location of map items which is useful in various use-cases like drone navigation, geo-plotting etc. Changes were also done to update related files which invoke the AnchorsEditor.

Asana: https://app.asana.com/0/1203851531040615/1205173127546645/f