### PR TITLE
fix(sdr): set fixed width for RecordStartView dialog

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
@@ -5,6 +5,9 @@
              xmlns:sdr="clr-namespace:Asv.Drones.Gui.Sdr"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d"
+             Width="450"
+             MinWidth="450"
+             MaxWidth="450"
              x:Class="Asv.Drones.Gui.Sdr.RecordStartView"
              x:DataType="sdr:RecordStartViewModel">
     <Design.DataContext>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartViewModel.cs
@@ -102,7 +102,7 @@ public class RecordStartViewModel : ViewModelBaseWithValidation
             
             TagName = "";
             TagValue = "";
-        });
+        }, this.IsValid());
         
         SelectedType = Types.First();
         


### PR DESCRIPTION
In this commit, I've enforced the width of the RecordStartView dialog to be 450 units. The Minimum and Maximum widths were also set to 450 units to ensure the dialog's size remains consistent across different user interactions. In addition, the button function in RecordStartViewModel was updated to only trigger if the information provided is valid. This is essential for preventing the application from accepting incorrect inputs, enhancing overall user experience and application's stability.

Asana: https://app.asana.com/0/1203851531040615/1205217582291092/f