### PR TITLE
fix(uav): add error handling to mission download

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusViewModel.cs
@@ -71,7 +71,14 @@ public class MissionStatusViewModel : ViewModelBase
 
     private async Task DownloadImpl(CancellationToken cancel)
     {
-        await _vehicle.Missions.Download(cancel,_ => DownloadProgress = _ * 100);
+        try
+        {
+            await _vehicle.Missions.Download(cancel, _ => DownloadProgress = _ * 100);
+        }
+        catch (Exception e)
+        {
+            _log.Error("MissionStatus", e.Message);
+        }
     }
     #endregion
 


### PR DESCRIPTION
The download implementation in MissionStatusViewModel now includes a try/catch block. This change aims to catch any exceptions that might occur during the mission download process. Previously, if the mission download failed for any reason, the error would not be caught, potentially causing a complete system crash. Now, such exceptions are caught and logged, preventing the system crash and providing a log message to aid in troubleshooting.

Asana: https://app.asana.com/0/1203851531040615/1205237266324943/f