### PR TITLE
fix(sdr): refactor UI elements in the SDR flight view

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrView.axaml
@@ -64,24 +64,22 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
             <Grid IsVisible="{Binding !IsIdleMode}">
-                <DockPanel IsVisible="{Binding !IsGpMode}">
-                    <ToggleButton IsChecked="{Binding IsChannelInput}" Margin="8 0 0 0" DockPanel.Dock="Right">
-                        <avalonia:MaterialIcon Kind="SwapHorizontal"/>
-                    </ToggleButton>
-                    <Grid>
-                        <TextBox IsVisible="{Binding !IsChannelInput}" Grid.Column="0" Text="{Binding FrequencyInMhz}">
-                            <TextBox.InnerRightContent>
-                                <TextBlock Margin="8 0" Text="{Binding FrequencyUnits}" VerticalAlignment="Center" />
-                            </TextBox.InnerRightContent>
-                        </TextBox>
-                        <AutoCompleteBox IsVisible="{Binding IsChannelInput}" Grid.Column="2" ItemsSource="{Binding Channels}" Text="{Binding Channel}"/>
-                    </Grid>
+                <DockPanel>
+                    <DropDownButton VerticalAlignment="Top" IsVisible="{CompiledBinding !IsGpMode}" Margin="8 0 0 0" DockPanel.Dock="Right">
+                        <avalonia:MaterialIcon Kind="Table"/>
+                        <DropDownButton.Flyout>
+                            <Flyout>
+                                <AutoCompleteBox Width="250" ItemsSource="{Binding Channels}" 
+                                                 Text="{Binding Channel}"/>
+                            </Flyout>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
+                    <TextBox Text="{Binding FrequencyInMhz}">
+                        <TextBox.InnerRightContent>
+                            <TextBlock Margin="8 0" Text="{Binding FrequencyUnits}" VerticalAlignment="Center" />
+                        </TextBox.InnerRightContent>
+                    </TextBox>
                 </DockPanel>
-                <TextBox IsVisible="{Binding IsGpMode}" Text="{Binding FrequencyInMhz}">
-                    <TextBox.InnerRightContent>
-                        <TextBlock Margin="8 0" Text="{Binding FrequencyUnits}" VerticalAlignment="Center" />
-                    </TextBox.InnerRightContent>
-                </TextBox>
             </Grid>
             <Button Command="{Binding UpdateMode}" HorizontalAlignment="Stretch">Set</Button>
             <ItemsControl ItemsSource="{Binding RttWidgets}">

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -301,9 +301,6 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
     public bool IsRecordVisible { get; set; }
     
     [Reactive]
-    public bool IsChannelInput { get; set; }
-    
-    [Reactive]
     public IEnumerable<string> Channels { get; set; }
     
     [Reactive]


### PR DESCRIPTION
The previous implementation of the UI for selecting channels in the SDR flight view was cluttered and ambiguous. This change replaces the ToggleButton with a DropDownButton, which is a more intuitive UI component. Now, when the user clicks the DropDownButton (represented by the Table icon), a list of available channels will appear, from which the user can select and the channel's respective frequency will be displayed in the TextBox. This implementation is more efficient and user-friendly. The 'IsChannelInput' reactive property was removed as it's no longer needed with the new UI design.

Asana: https://app.asana.com/0/1203851531040615/1205307075789323/f