### PR TITLE
fix(sdr): update language resources and UI for clarity

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -348,7 +348,7 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Record name.
+        ///   Looks up a localized string similar to Record name (required).
         /// </summary>
         public static string RecordStartView_RecordName_Title {
             get {
@@ -362,6 +362,15 @@ namespace Asv.Drones.Gui.Sdr {
         public static string RecordStartView_RecordName_Watermark {
             get {
                 return ResourceManager.GetString("RecordStartView_RecordName_Watermark", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Record tags (optional).
+        /// </summary>
+        public static string RecordStartView_RecordTags_Title {
+            get {
+                return ResourceManager.GetString("RecordStartView_RecordTags_Title", resourceCulture);
             }
         }
         

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -196,7 +196,7 @@
         <value>Not valid record name</value>
     </data>
     <data name="RecordStartView_RecordName_Title" xml:space="preserve">
-        <value>Record name</value>
+        <value>Record name (required)</value>
     </data>
     <data name="RecordStartView_RecordName_Watermark" xml:space="preserve">
         <value>Enter new record name</value>
@@ -242,5 +242,8 @@
     </data>
     <data name="SdrStoreEntityViewModel_Name_Validation_ErrorMessage" xml:space="preserve">
         <value>Not valid record name</value>
+    </data>
+    <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
+        <value>Record tags (optional)</value>
     </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -189,7 +189,7 @@
         <value>Недопустимое имя записи</value>
     </data>
     <data name="RecordStartView_RecordName_Title" xml:space="preserve">
-        <value>Имя записи</value>
+        <value>Имя записи (обязательно)</value>
     </data>
     <data name="RecordStartView_RecordName_Watermark" xml:space="preserve">
         <value>Введите имя для новой записи</value>
@@ -235,5 +235,8 @@
     </data>
     <data name="SdrStoreEntityViewModel_Name_Validation_ErrorMessage" xml:space="preserve">
         <value>Недопустимое имя записи</value>
+    </data>
+    <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
+        <value>Теги записи (опционально)</value>
     </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Dialogs/RecordStartView.axaml
@@ -5,6 +5,7 @@
              xmlns:sdr="clr-namespace:Asv.Drones.Gui.Sdr"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d"
+             Height="350"
              Width="450"
              MinWidth="450"
              MaxWidth="450"
@@ -14,83 +15,91 @@
         <sdr:RecordStartViewModel/>
     </Design.DataContext>
     
-    <StackPanel Margin="8" Spacing="8">
-        <TextBlock Text="{x:Static sdr:RS.RecordStartView_RecordName_Title}" FontSize="20"/>
-        <TextBox Watermark="{x:Static sdr:RS.RecordStartView_RecordName_Watermark}" Text="{Binding RecordName}"/>
-        <ItemsControl DockPanel.Dock="Top" ItemsSource="{Binding Tags}">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <WrapPanel Orientation="Horizontal"/>
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.DataTemplates>
-                <DataTemplate DataType="sdr:LongTagViewModel">
-                    <Border Margin="4" Background="CornflowerBlue" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
-                        <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
-                            <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
-                                <TextBlock FontSize="12" Foreground="White" Text=": "/>
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
-                            </StackPanel>
-                            <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
-                                <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
-                            </Button>
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-                <DataTemplate DataType="sdr:ULongTagViewModel">
-                    <Border Margin="4" Background="#FE8256" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
-                        <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
-                            <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
-                                <TextBlock FontSize="12" Foreground="White" Text=": "/>
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
-                            </StackPanel>
-                            <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
-                                <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
-                            </Button>
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-                <DataTemplate DataType="sdr:DoubleTagViewModel">
-                    <Border Margin="4" Background="#ACC865" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
-                        <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
-                            <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
-                                <TextBlock FontSize="12" Foreground="White" Text=": "/>
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
-                            </StackPanel>
-                            <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="16" Height="16" Command="{Binding Remove}">
-                                <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
-                            </Button>
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-                <DataTemplate DataType="sdr:StringTagViewModel">
-                    <Border Margin="4" Background="#CD91B6" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
-                        <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
-                            <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
-                                <TextBlock FontSize="12" Foreground="White" Text=": "/>
-                                <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
-                            </StackPanel>
-                            <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
-                                <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
-                            </Button>
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-            </ItemsControl.DataTemplates>
-        </ItemsControl>
-        <Grid ColumnDefinitions="*, 4, 100, 4, Auto">
-            <TextBox Grid.Column="0" Watermark="{x:Static sdr:RS.RecordStartView_TagName_Watermark}" Text="{Binding TagName}"/>
-            <ComboBox Grid.Column="2" Width="100" ItemsSource="{Binding Types}" SelectedItem="{Binding SelectedType}"/>
-            <Button Grid.Column="4" Content="{x:Static sdr:RS.RecordStartView_AddButton_Title}" Command="{Binding AddTag}" VerticalAlignment="Top"/>
-        </Grid>
-        <TextBox Watermark="{x:Static sdr:RS.RecordStartView_TagValue_Watermark}" Text="{Binding TagValue}"/>
-    </StackPanel>
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="8" Spacing="8">
+            <TextBlock Text="{x:Static sdr:RS.RecordStartView_RecordName_Title}" FontSize="20"/>
+            <TextBox Watermark="{x:Static sdr:RS.RecordStartView_RecordName_Watermark}" Text="{Binding RecordName}"/>
+        </StackPanel>
+        <Expander Header="{x:Static sdr:RS.RecordStartView_RecordTags_Title}" FontSize="15">
+            <ScrollViewer>
+                <StackPanel Margin="10" Spacing="8">
+                    <ItemsControl DockPanel.Dock="Top" ItemsSource="{Binding Tags}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.DataTemplates>
+                            <DataTemplate DataType="sdr:LongTagViewModel">
+                                <Border Margin="4" Background="CornflowerBlue" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
+                                    <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
+                                        <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
+                                        <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
+                                            <TextBlock FontSize="12" Foreground="White" Text=": "/>
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
+                                        </StackPanel>
+                                        <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
+                                            <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                            <DataTemplate DataType="sdr:ULongTagViewModel">
+                                <Border Margin="4" Background="#FE8256" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
+                                    <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
+                                        <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
+                                        <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
+                                            <TextBlock FontSize="12" Foreground="White" Text=": "/>
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
+                                        </StackPanel>
+                                        <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
+                                            <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                            <DataTemplate DataType="sdr:DoubleTagViewModel">
+                                <Border Margin="4" Background="#ACC865" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
+                                    <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
+                                        <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
+                                        <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
+                                            <TextBlock FontSize="12" Foreground="White" Text=": "/>
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
+                                        </StackPanel>
+                                        <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="16" Height="16" Command="{Binding Remove}">
+                                            <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                            <DataTemplate DataType="sdr:StringTagViewModel">
+                                <Border Margin="4" Background="#CD91B6" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
+                                    <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
+                                        <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
+                                        <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Name}"/>
+                                            <TextBlock FontSize="12" Foreground="White" Text=": "/>
+                                            <TextBlock FontSize="12" Foreground="White" Text="{Binding Value}"/>
+                                        </StackPanel>
+                                        <Button VerticalAlignment="Center" BorderThickness="0" Background="Transparent" Width="18" Height="18" Command="{Binding Remove}">
+                                            <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.DataTemplates>
+                    </ItemsControl>
+                    <Grid ColumnDefinitions="*, 4, 100, 4, Auto">
+                        <TextBox Grid.Column="0" Watermark="{x:Static sdr:RS.RecordStartView_TagName_Watermark}" Text="{Binding TagName}"/>
+                        <ComboBox Grid.Column="2" Width="100" ItemsSource="{Binding Types}" SelectedItem="{Binding SelectedType}"/>
+                        <Button Grid.Column="4" Content="{x:Static sdr:RS.RecordStartView_AddButton_Title}" Command="{Binding AddTag}" VerticalAlignment="Top"/>
+                    </Grid>
+                    <TextBox Watermark="{x:Static sdr:RS.RecordStartView_TagValue_Watermark}" Text="{Binding TagValue}"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Expander>
+    </DockPanel>
 </UserControl>


### PR DESCRIPTION
Updated some language resource files (both English and Russian versions) to clarify which fields are required and which are optional. Specifically, the 'Record Name' now indicates that it is a required field, and 'Record Tags' shows it as optional. This change improves overall user experience by providing clear instructions to the user.

Also updated the RecordStartView.axaml to shift the tags into an expandable format rather than off to the side. This enhances the user experience by offering a clearer, more organized display of tags.

Asana: https://app.asana.com/0/1203851531040615/1205310916333555/f