### PR TITLE
fix(sdr): update default case in Sdr flight model

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -59,7 +59,7 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _config = _configuration.Get<FlightSdrViewModelConfig>();
         _freqInMHzMeasureUnit = _loc.Frequency.AvailableUnits.First(_ => _.Id == Core.FrequencyUnits.MHz);
-
+        
         this.WhenAnyValue(_ => _.SelectedMode)
             .Subscribe(_ =>
             {
@@ -87,7 +87,8 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
                             IsGpMode = false;
                             break;
                         case AsvSdrCustomMode.AsvSdrCustomModeIdle: 
-                        default: 
+                        default:
+                            FrequencyInMhz = "0";
                             IsIdleMode = true;
                             IsGpMode = false;
                             break;


### PR DESCRIPTION
This commit sets the 'FrequencyInMhz' field to "0" in the default case of the 'AsvSdrCustomMode' switch. It ensures that when the drone is in the idle mode, its frequency is always set to 0 MHz. This action will avoid any potential issues arising from unexpected frequency values in the idle state.