### PR TITLE
fix (core): update altitude formatting to 2 decimal places

### DIFF
--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Altitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Altitude.cs
@@ -14,8 +14,8 @@ public class Altitude : MeasureUnitBase<double,AltitudeUnits>
     private const double MetersInFeet = 0.3048;
 
     private static readonly IMeasureUnitItem<double, AltitudeUnits>[] _units = {
-        new DoubleMeasureUnitItem<AltitudeUnits>(AltitudeUnits.Meters,RS.Altitude_Meter_Title,RS.Altitude_Meter_Unit,true, "F0",1),
-        new DoubleMeasureUnitItem<AltitudeUnits>(AltitudeUnits.Feets,RS.Altitude_Feet_Title,RS.Altitude_Feet_Unit,false,"F0",MetersInFeet),
+        new DoubleMeasureUnitItem<AltitudeUnits>(AltitudeUnits.Meters,RS.Altitude_Meter_Title,RS.Altitude_Meter_Unit,true, "F2",1),
+        new DoubleMeasureUnitItem<AltitudeUnits>(AltitudeUnits.Feets,RS.Altitude_Feet_Title,RS.Altitude_Feet_Unit,false,"F2",MetersInFeet),
     };
     public Altitude(IConfiguration cfgSvc, string cfgKey) : base(cfgSvc, cfgKey,_units)
     {


### PR DESCRIPTION
The decimal format specifier in our Altitude service was updated from "F0" to "F2", to include 2 decimal places. This minor change for both Meters and Feet drastically improves the precision of altitude calculations and readouts in our GUI.

Asana: https://app.asana.com/0/1203851531040615/1205361528081959/f