### PR TITLE
fix: update mission status view with total and mission distances

### DIFF
--- a/src/Asv.Drones.Gui.Uav/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Uav/RS.Designer.cs
@@ -276,6 +276,15 @@ namespace Asv.Drones.Gui.Uav {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mission: {0}.
+        /// </summary>
+        public static string MissionStatusView_MissionDistance {
+            get {
+                return ResourceManager.GetString("MissionStatusView_MissionDistance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Current mission progress.
         /// </summary>
         public static string MissionStatusView_MissionProgress_ToolTip {
@@ -305,9 +314,9 @@ namespace Asv.Drones.Gui.Uav {
         /// <summary>
         ///   Looks up a localized string similar to Total: {0}.
         /// </summary>
-        public static string MissionStatusView_Total {
+        public static string MissionStatusView_TotalDistance {
             get {
-                return ResourceManager.GetString("MissionStatusView_Total", resourceCulture);
+                return ResourceManager.GetString("MissionStatusView_TotalDistance", resourceCulture);
             }
         }
         

--- a/src/Asv.Drones.Gui.Uav/RS.resx
+++ b/src/Asv.Drones.Gui.Uav/RS.resx
@@ -108,8 +108,8 @@
     <data name="MissionStatusView_ToggleWaypointsButton_ToolTip" xml:space="preserve">
     <value>On/off mission way points visibility</value>
   </data>
-    <data name="MissionStatusView_Total" xml:space="preserve">
-    <value>Total: {0}</value>
+  <data name="MissionStatusView_MissionDistance" xml:space="preserve">
+    <value>Mission: {0}</value>
   </data>
     <data name="MissionStatusView_MissionProgress_ToolTip" xml:space="preserve">
     <value>Current mission progress</value>
@@ -332,5 +332,8 @@
   </data>
   <data name="FlightUavView_FindButton_ToolTip" xml:space="preserve">
     <value>Find UAV</value>
+  </data>
+  <data name="MissionStatusView_TotalDistance" xml:space="preserve">
+    <value>Total: {0}</value>
   </data>
 </root>

--- a/src/Asv.Drones.Gui.Uav/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Uav/RS.ru.resx
@@ -101,10 +101,7 @@
     <data name="MissionStatusView_ToggleWaypointsButton_ToolTip" xml:space="preserve">
     <value>Включает/выключает видимость точек миссии</value>
   </data>
-    <data name="MissionStatusView_Total" xml:space="preserve">
-    <value>Всего: {0}</value>
-  </data>
-    <data name="MissionStatusView_MissionProgress_ToolTip" xml:space="preserve">
+  <data name="MissionStatusView_MissionProgress_ToolTip" xml:space="preserve">
     <value>Текущий прогресс миссии</value>
   </data>
     <data name="ParametersEditorPageView_StarsToggleButton_ToolTip" xml:space="preserve">
@@ -325,5 +322,11 @@
   </data>
   <data name="FlightUavView_FindButton_ToolTip" xml:space="preserve">
     <value>Найти БПЛА</value>
+  </data>
+  <data name="MissionStatusView_TotalDistance" xml:space="preserve">
+    <value>Всего: {0}</value>
+  </data>
+  <data name="MissionStatusView_MissionDistance" xml:space="preserve">
+    <value>Миссия: {0}</value>
   </data>
 </root>

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusView.axaml
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusView.axaml
@@ -3,7 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:uav="clr-namespace:Asv.Drones.Gui.Uav"
-             xmlns:uav1="clr-namespace:Asv.Drones.Gui.Uav.Uav"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:missionStatus="clr-namespace:Asv.Drones.Gui.Uav.MissionStatus"
              mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="105"
@@ -28,7 +27,7 @@
                 <ToggleButton ToolTip.Tip="{x:Static uav:RS.MissionStatusView_ToggleWaypointsButton_ToolTip}" IsChecked="{CompiledBinding EnableAnchors}">
                     <avalonia:MaterialIcon Kind="Anchor"/>
                 </ToggleButton>
-                <StackPanel Margin="5 0" VerticalAlignment="Center" HorizontalAlignment="Right" Orientation="Horizontal">
+                <WrapPanel Margin="5 0" VerticalAlignment="Center" HorizontalAlignment="Right" Orientation="Horizontal">
                     <Grid VerticalAlignment="Center" Margin="5 0">
                         <Ellipse Fill="Black" Width="15" Height="15" Stroke="White" StrokeThickness="2"/>
                         <Ellipse Fill="White" Width="7" Height="7"/>
@@ -39,10 +38,10 @@
                         <Ellipse Fill="Black" Width="15" Height="15" Stroke="White" StrokeThickness="2"/>
                     </Grid>
                     <TextBlock Text="{Binding CurrentIndex, StringFormat='WP {0}'}"/>
-                    <TextBlock Margin="5 0" Text="{Binding Total, StringFormat={x:Static uav:RS.MissionStatusView_Total}}"/>
-                </StackPanel>
+                    <TextBlock Margin="5 0" Text="{Binding TotalDistance, StringFormat={x:Static uav:RS.MissionStatusView_TotalDistance}}"/>
+                    <TextBlock Margin="5 0" Text="{Binding MissionDistance, StringFormat={x:Static uav:RS.MissionStatusView_MissionDistance}}"/>
+                </WrapPanel>
             </WrapPanel>
-            
         </Grid>
         <Grid ToolTip.Tip="{x:Static uav:RS.MissionStatusView_MissionProgress_ToolTip}" Height="20" Margin="10">
             <Rectangle>


### PR DESCRIPTION
This commit addresses changes in the mission status view regarding total & mission distances. Previously, the mission status view only displayed the total distance of all waypoints. Now, however, it is indeed enhanced to show the distance of the current mission, which is more relevant data to the user. Also, total distance now accounts for the distance from and to the home point.

This change aims to provide a clearer overview of distance-related metrics, thus assisting the user in staying aware of the drone's status and progress throughout the mission.

These modifications are reflected not only on the display elements and tooltips but also on the underlying ViewModel, where the calculation of the total distance has been adjusted to consider the home point distance. Besides, it includes changes in the localization files.

Asana: https://app.asana.com/0/1203851531040615/1205412828145386/f