### PR TITLE
fix: add reactive focus controls and validation checks in AnchorsEdit…

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Widgets/AnchorsEditorView.axaml
@@ -20,7 +20,8 @@
             </StackPanel>
             <Grid ColumnDefinitions="*, 15, 3*">
                 <TextBlock Text="Latitude" TextWrapping="NoWrap" Grid.Column="0"/>
-                <TextBox Text="{CompiledBinding Latitude}" Grid.Column="2" 
+                <TextBox Text="{CompiledBinding Latitude}" Grid.Column="2"
+                         IsFocused="{CompiledBinding IsLatFocused, Mode=OneWayToSource}"
                          IsReadOnly="{CompiledBinding !Map.SelectedItem.IsInEditMode}" 
                          IsEnabled="{CompiledBinding Map.SelectedItem.IsEditable}">
                     <TextBox.InnerRightContent>
@@ -31,6 +32,7 @@
             <Grid ColumnDefinitions="*, 15, 3*">
                 <TextBlock Text="Longitude" Grid.Column="0"/>
                 <TextBox Text="{CompiledBinding Longitude}" Grid.Column="2" 
+                         IsFocused="{CompiledBinding IsLonFocused, Mode=OneWayToSource}"
                          IsReadOnly="{CompiledBinding !Map.SelectedItem.IsInEditMode}" 
                          IsEnabled="{CompiledBinding Map.SelectedItem.IsEditable}">
                     <TextBox.InnerRightContent>
@@ -40,7 +42,8 @@
             </Grid>
             <Grid ColumnDefinitions="*, 15, 3*">
                 <TextBlock Text="Altitude" Grid.Column="0"/>
-                <TextBox Text="{CompiledBinding Altitude}" Grid.Column="2" 
+                <TextBox Text="{CompiledBinding Altitude}" Grid.Column="2"
+                         IsFocused="{CompiledBinding IsAltFocused, Mode=OneWayToSource}"
                          IsReadOnly="{CompiledBinding !Map.SelectedItem.IsInEditMode}" 
                          IsEnabled="{CompiledBinding Map.SelectedItem.IsEditable}">
                     <TextBox.InnerRightContent>


### PR DESCRIPTION
…orViewModel

The AnchorsEditorViewModel has been modified to include reactive properties for controlling focus on latitude, longitude and altitude fields. The changes have been made to improve input efficiency and spot invalid inputs. Previously, location updates were directly tied to changes in any of these fields. Now, values are only updated when the specific field loses focus, preventing unnecessary and potentially erroneous updates. Validation checks and error responses have been moved into separate methods for better code readability and organization. UI elements in the AnchorsEditorView have been modified to bind to the new focus controls.

Asana: https://app.asana.com/0/1203851531040615/1205517122543116/f