### PR TITLE
feat: change hotkey for editAnchorsToggleButton

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Actions/AnchorMover/AnchorMoverActionView.axaml.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Actions/AnchorMover/AnchorMoverActionView.axaml.cs
@@ -13,6 +13,6 @@ public partial class AnchorMoverActionView : ReactiveUserControl<AnchorMoverActi
     public AnchorMoverActionView()
     {
         InitializeComponent();
-        HotKeyManager.SetHotKey(editAnchorsToggleButton, new KeyGesture(Key.LeftCtrl, KeyModifiers.Control));
+        HotKeyManager.SetHotKey(editAnchorsToggleButton, new KeyGesture(Key.LeftAlt, KeyModifiers.Alt));
     }
 }


### PR DESCRIPTION
Hotkey for the editAnchorsToggleButton in AnchorMoverActionView was changed from LeftCtrl to LeftAlt. This change provides a more intuitive and less conflicting key configuration for users.

Asana: https://app.asana.com/0/1203851531040615/1205527219350697/f