### PR TITLE
feat (sdr): update record name with timestamp and selected mode

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -208,7 +208,10 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
         };
             
         var viewModel = new RecordStartViewModel();
-            
+        
+        if (SelectedMode != null) 
+            viewModel.RecordName = $"{DateTime.Now:YY_MM_DD_HH_MM}_{SelectedMode.Mode}";
+        
         viewModel.ApplyDialog(dialog);
             
         dialog.Content = viewModel;
@@ -366,7 +369,7 @@ public class SdrModeViewModel:ReactiveObject
     public string Name { get; }
     public AsvSdrCustomMode Mode { get; }
 
-    public SdrModeViewModel(string name, AsvSdrCustomMode mode,MaterialIconKind icon)
+    public SdrModeViewModel(string name, AsvSdrCustomMode mode, MaterialIconKind icon)
     {
         Name = name;
         Mode = mode;


### PR DESCRIPTION
This commit updates how the `RecordName` property is being assigned in the `FlightSdrViewModel` class. If there is a `SelectedMode`, it will append the current timestamp and the mode to form a unique recording name. The update aims at improving recording tracking and management by having more descriptive and informative recording names

Asana: https://app.asana.com/0/1203851531040615/1205628819726104/f