### PR TITLE
fix (loc): reduce precision in printing coordinates

### DIFF
--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Latitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Latitude.cs
@@ -57,16 +57,16 @@ public class LatitudeUnitDeg : IMeasureUnitItem<double, LatitudeUnits>
 
     public string Print(double value)
     {
-        return value.ToString("F7");
+        return value.ToString("F6");
     }
 
     public string PrintWithUnits(double value)
     {
-        return $"{value:F7}°";
+        return $"{value:F6}°";
     }
     public string FromSiToStringWithUnits(double value)
     {
-        return $"{value:F7}°";
+        return $"{value:F6}°";
     }
 }
 

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Longitude.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Longitude.cs
@@ -56,14 +56,18 @@ public class LongitudeUnitDeg :  IMeasureUnitItem<double, LongitudeUnits>
 
     public string Print(double value)
     {
-        return value.ToString("F7");
+        return value.ToString("F6");
     }
 
     public string PrintWithUnits(double value)
     {
-        return $"{value:F7}°";
+        return $"{value:F6}°";
     }
-
+    
+    public string FromSiToStringWithUnits(double value)
+    {
+        return $"{value:F6}°";
+    }
 }
 
 public class LongitudeUnitDms : IMeasureUnitItem<double, LongitudeUnits>


### PR DESCRIPTION
Changes have been made to reduce the precision of the printed coordinates from 7 decimal places to 6 in the "Latitude.cs" and "Longitude.cs" classes. This decision was made to streamline data presentation by limiting unnecessary precision, improving readability without significantly impacting accuracy.

Asana: https://app.asana.com/0/1203851531040615/1205678012462557/f