### PR TITLE
feat(core): update HierarchicalStore View and ViewModel

### DIFF
--- a/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreView.axaml
+++ b/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreView.axaml
@@ -70,7 +70,7 @@
                     <TreeView SelectionMode="Toggle" Margin="0,8,0,8" ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
                         <TreeView.ItemTemplate>
                             <TreeDataTemplate ItemsSource="{Binding Items}">
-                                <DockPanel HorizontalAlignment="Stretch">
+                                <DockPanel HorizontalAlignment="Stretch" LastChildFill="False">
                                     <avalonia:MaterialIcon
                                         Margin="0,0,8,0"
                                         Classes.folder="{Binding IsFolder}"
@@ -79,7 +79,7 @@
                                         Classes.selected="{Binding IsSelected}"
                                         Width="15" Height="15"/>
                                     <TextBlock MinWidth="120" Text="{Binding Name}"/>
-                                    <TextBlock Foreground="Gray" Text="{Binding Description}"/>
+                                    <TextBlock DockPanel.Dock="Right" Foreground="Gray" Text="{Binding Description}"/>
                                 </DockPanel>
                             </TreeDataTemplate>
                         </TreeView.ItemTemplate>

--- a/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -347,6 +348,22 @@ public abstract class HierarchicalStoreViewModel<TKey,TFile>:HierarchicalStoreVi
    
     public virtual string GetEntryDescription(IHierarchicalStoreEntry<TKey> nodeItem)
     {
+        var entry = nodeItem as FileSystemHierarchicalStoreEntry<TKey>;
+        
+        if (entry == null) return string.Empty;
+        
+        if (nodeItem.Type == FolderStoreEntryType.Folder)
+        {
+            var info = new DirectoryInfo(entry.FullPath);
+            return info.CreationTime.ToString(CultureInfo.CurrentCulture);
+        }
+        
+        if(nodeItem.Type == FolderStoreEntryType.File)
+        {
+            var info = new FileInfo(entry.FullPath);
+            return info.CreationTime.ToString(CultureInfo.CurrentCulture);
+        }
+        
         return string.Empty;
     }
 }


### PR DESCRIPTION
Modified HierarchicalStore View layout to improve readability and introduced creation time display for files/folders in HierarchicalStore ViewModel. In the view, the adjustment prevents the last child of the Dockpanel from filling the whole available space for better UI. Description text is now docked to the right for clarity. Additionally, the ViewModel now includes the creation time display for files/folders when type details are fetched for FileSystemHierarchicalStoreEntry items. This provides more detailed information for the user.

Asana: https://app.asana.com/0/1203851531040615/1205628819726102/f