### PR TITLE
feat: add delete functionality to SdrPayloadRecordViewModel

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
@@ -118,12 +118,13 @@ public class SdrDeviceViewModel:ViewModelBase
         _log = log;
         Client = device;
         device.Sdr.Records
-            .Transform(_=>new SdrPayloadRecordViewModel(device.Heartbeat.FullId,_,_log,_loc))
+            .Transform(_=>new SdrPayloadRecordViewModel(device.Heartbeat.FullId,_,_log,_loc, device.Sdr))
             .SortBy(_=>_.CreatedDateTime)
             .Bind(out _items)
             .DisposeMany()
             .Subscribe()
             .DisposeItWith(Disposable);
+        
         this.WhenValueChanged(_ => SelectedRecord)
             .Where(_=>_ != null)
             .Subscribe(_=>_.DownloadTags.Execute().Subscribe())


### PR DESCRIPTION
A reference to IAsvSdrClientEx was added to SdrPayloadRecordViewModel to enable record deletion. The 'Delete' command is now created from a task invoking 'DeleteRecord' on _sdrClient. Consequently, SdrPayloadBrowserViewModel was also updated to pass IAsvSdrClientEx while transforming records.

Asana: https://app.asana.com/0/1203851531040615/1203719678217452/f