### PR TITLE
feat: add sorting functionality to SdrPayloadBrowserView

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserView.axaml
@@ -12,7 +12,6 @@
         <SolidColorBrush x:Key="FolderBrush" Color="#FBC02D"/>
         <SolidColorBrush x:Key="FileBrush" Color="#40b5e0"/>
         <SolidColorBrush x:Key="DeleteBrush" Color="#D84315"/>
-        <x:Double x:Key="IconSize">18</x:Double>
     </UserControl.Resources>
     <Design.DataContext>
         <sdr:SdrPayloadBrowserViewModel/>
@@ -23,8 +22,7 @@
             <RowDefinition Height="5"/>
             <RowDefinition Height="200" MinHeight="200"/>
         </Grid.RowDefinitions>
-        <Border
-            Grid.Row="0"
+        <Border Grid.Row="0"
             Background="{DynamicResource ControlFillColorDefaultBrush}"
             BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
             BorderThickness="1"
@@ -35,6 +33,29 @@
                     <Button DockPanel.Dock="Right" Margin="8,0,0,0"  Command="{Binding SelectedDevice.DownloadRecords}">
                         <avalonia:MaterialIcon Kind="Refresh" Foreground="{StaticResource FileBrush}" />
                     </Button>
+                    <DropDownButton IsEnabled="{CompiledBinding SelectedDevice, Converter={x:Static ObjectConverters.IsNotNull}}" 
+                                    DockPanel.Dock="Right" Margin="8,0,0,0">
+                        <DropDownButton.Flyout>
+                            <Flyout>
+                                <StackPanel Spacing="8">
+                                    <TextBlock Text="{x:Static sdr:RS.SdrPayloadBrowserView_Sort_Title}"/>
+                                    <ToggleButton IsChecked="{CompiledBinding SelectedDevice.IsSortByName}" >
+                                        <StackPanel Orientation="Horizontal">
+                                            <avalonia:MaterialIcon Kind="Abc"/>
+                                            <TextBlock Text="{x:Static sdr:RS.SdrPayloadBrowserView_Sort_By_Name}"/>
+                                        </StackPanel>
+                                    </ToggleButton>
+                                    <ToggleButton IsChecked="{CompiledBinding !SelectedDevice.IsSortByName}">
+                                        <StackPanel Orientation="Horizontal">
+                                            <avalonia:MaterialIcon Kind="DateRange"/>
+                                            <TextBlock Text="{x:Static sdr:RS.SdrPayloadBrowserView_Sort_By_Date}"/>
+                                        </StackPanel>
+                                    </ToggleButton>
+                                </StackPanel>
+                            </Flyout>
+                        </DropDownButton.Flyout>
+                        <avalonia:MaterialIcon Kind="Sort" Foreground="{StaticResource FileBrush}" />
+                    </DropDownButton>
                     <ComboBox ItemsSource="{Binding Devices}" HorizontalAlignment="Stretch" SelectedItem="{Binding SelectedDevice}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
@@ -100,11 +121,10 @@
                                 </Style>
                             </avalonia:MaterialIcon.Styles>
                         </avalonia:MaterialIcon>
-                                
-                        <Button
-                            Name="PART_Delete" 
+                        <Button Name="PART_Delete" 
                             IsHitTestVisible="True" Padding="3" 
-                            DockPanel.Dock="Right" Theme="{DynamicResource TransparentButton}" Command="{Binding SelectedRecord.Delete}">
+                            DockPanel.Dock="Right" Theme="{DynamicResource TransparentButton}" 
+                            Command="{Binding SelectedRecord.Delete}">
                             <avalonia:MaterialIcon Kind="Close" Width="18" Height="18" Foreground="#D84315"/>
                         </Button>
                         <TextBlock VerticalAlignment="Center" Text="{Binding SelectedRecord.Name}"/>

--- a/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
@@ -118,8 +118,8 @@ public class SdrDeviceViewModel:ViewModelBase
         _log = log;
         Client = device;
         device.Sdr.Records
-            .Transform(_=>new SdrPayloadRecordViewModel(device.Heartbeat.FullId,_,_log,_loc, device.Sdr))
-            .SortBy(_=>_.CreatedDateTime)
+            .Transform(_=>new SdrPayloadRecordViewModel(device.Heartbeat.FullId, _, _log, _loc, device.Sdr))
+            .SortBy(_ => IsSortByName ? _.Name : _.CreatedDateTime)
             .Bind(out _items)
             .DisposeMany()
             .Subscribe()
@@ -145,6 +145,9 @@ public class SdrDeviceViewModel:ViewModelBase
             .DisposeItWith(Disposable);
     }
 
+    [Reactive] 
+    public bool IsSortByName { get; set; } = true;
+    
     [Reactive]
     public double DownloadRecordsProgress { get; set; }
     public ReactiveCommand<Unit,bool> DownloadRecords { get; }

--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -447,6 +447,33 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Date.
+        /// </summary>
+        public static string SdrPayloadBrowserView_Sort_By_Date {
+            get {
+                return ResourceManager.GetString("SdrPayloadBrowserView_Sort_By_Date", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        public static string SdrPayloadBrowserView_Sort_By_Name {
+            get {
+                return ResourceManager.GetString("SdrPayloadBrowserView_Sort_By_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sort by:.
+        /// </summary>
+        public static string SdrPayloadBrowserView_Sort_Title {
+            get {
+                return ResourceManager.GetString("SdrPayloadBrowserView_Sort_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to N\A.
         /// </summary>
         public static string SdrRttItem_ValueNotAvailable {

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -246,4 +246,13 @@
     <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
         <value>Record tags (optional)</value>
     </data>
+    <data name="SdrPayloadBrowserView_Sort_Title" xml:space="preserve">
+        <value>Sort by:</value>
+    </data>
+    <data name="SdrPayloadBrowserView_Sort_By_Name" xml:space="preserve">
+        <value>Name</value>
+    </data>
+    <data name="SdrPayloadBrowserView_Sort_By_Date" xml:space="preserve">
+        <value>Date</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -239,4 +239,13 @@
     <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
         <value>Теги записи (опционально)</value>
     </data>
+    <data name="SdrPayloadBrowserView_Sort_Title" xml:space="preserve">
+        <value>Сортировать по:</value>
+    </data>
+    <data name="SdrPayloadBrowserView_Sort_By_Name" xml:space="preserve">
+        <value>Имени</value>
+    </data>
+    <data name="SdrPayloadBrowserView_Sort_By_Date" xml:space="preserve">
+        <value>Дате</value>
+    </data>
 </root>


### PR DESCRIPTION
Added a sorting functionality to the SdrPayloadBrowserView which allows users to sort payloads by either name or date. A dropdown button has been included in the GUI to enable the users to toggle between the sorting preferences. This update is essential to enhance usability and improve the user experience, especially when dealing with a large collection of payloads. The change has been reflected in both English and Russian localizations.

Asana: https://app.asana.com/0/1203851531040615/1203719678217452/f