### PR TITLE
fix: update behavior after dialog closes

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
@@ -184,7 +184,11 @@ namespace Asv.Drones.Gui.Core
             IsInDialogMode = true;
             var tcs = new TaskCompletionSource();
             await using var c1 = cancel.Register(() => tcs.TrySetCanceled());
-            this.WhenAnyValue(_ => _.IsInDialogMode).Where(_ => IsInDialogMode == false).Subscribe(_ => tcs.TrySetResult(), cancel);
+            this.WhenAnyValue(_ => _.IsInDialogMode).Where(_ => IsInDialogMode == false).Subscribe(_ =>
+            {
+                tcs.TrySetResult();
+                SelectedItem = null;
+            }, cancel);
             await tcs.Task;
             return DialogTarget;
         }


### PR DESCRIPTION
Updated the behavior of `MapPageViewModel` after a dialog closes. Now `SelectedItem` is reset to null, ensuring the previously selected item is not retained erroneously. This change should prevent potential inconsistencies in item selection and improve user interactions.

Asana: https://app.asana.com/0/1203851531040615/1205646452870160/f