### PR TITLE
feat: added SDR configurations in settings page.

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Asv.Drones.Gui.Sdr.csproj.DotSettings
+++ b/src/Asv.Drones.Gui.Sdr/Asv.Drones.Gui.Sdr.csproj.DotSettings
@@ -20,5 +20,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cflight_005Cwidgets_005Csdr_005Crtt_005Cvor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Crecordstore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Csdr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Csettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Csettings_005Csdr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=shell_005Cpages_005Cstore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=tools/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Sdr/RS.Designer.cs
@@ -492,6 +492,168 @@ namespace Asv.Drones.Gui.Sdr {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default data thinning frequency..
+        /// </summary>
+        public static string SdrSettingsViewModel_DataThinning_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_DataThinning_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data thinning.
+        /// </summary>
+        public static string SdrSettingsViewModel_DataThinning_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_DataThinning_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default channels.
+        /// </summary>
+        public static string SdrSettingsViewModel_DefaultChannels_Title {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_DefaultChannels_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default frequencies.
+        /// </summary>
+        public static string SdrSettingsViewModel_DefaultFreqs_Title {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_DefaultFreqs_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section, you can configure various SDR parameters..
+        /// </summary>
+        public static string SdrSettingsViewModel_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default frequency of writing to file..
+        /// </summary>
+        public static string SdrSettingsViewModel_FileWriteFreq_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_FileWriteFreq_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Frequency of writing to file.
+        /// </summary>
+        public static string SdrSettingsViewModel_FileWriteFreq_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_FileWriteFreq_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default GP frequency..
+        /// </summary>
+        public static string SdrSettingsViewModel_GpFreq_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_GpFreq_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GP frequency.
+        /// </summary>
+        public static string SdrSettingsViewModel_GpFreq_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_GpFreq_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SDR settings.
+        /// </summary>
+        public static string SdrSettingsViewModel_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default LLZ channel..
+        /// </summary>
+        public static string SdrSettingsViewModel_LLzChannel_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_LLzChannel_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LLZ channel.
+        /// </summary>
+        public static string SdrSettingsViewModel_LlzChannel_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_LlzChannel_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default LLZ frequency..
+        /// </summary>
+        public static string SdrSettingsViewModel_LLzFreq_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_LLzFreq_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LLZ frequency.
+        /// </summary>
+        public static string SdrSettingsViewModel_LlzFreq_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_LlzFreq_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default VOR channel..
+        /// </summary>
+        public static string SdrSettingsViewModel_VorChannel_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_VorChannel_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VOR channel.
+        /// </summary>
+        public static string SdrSettingsViewModel_VorChannel_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_VorChannel_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this section you can configure the default VOR frequency..
+        /// </summary>
+        public static string SdrSettingsViewModel_VorFreq_Description {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_VorFreq_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VOR frequency.
+        /// </summary>
+        public static string SdrSettingsViewModel_VorFreq_Header {
+            get {
+                return ResourceManager.GetString("SdrSettingsViewModel_VorFreq_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search.
         /// </summary>
         public static string SdrStoreBrowserViewModel_SearchWatermark {

--- a/src/Asv.Drones.Gui.Sdr/RS.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.resx
@@ -246,4 +246,58 @@
     <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
         <value>Record tags (optional)</value>
     </data>
+    <data name="SdrSettingsViewModel_Header" xml:space="preserve">
+        <value>SDR settings</value>
+    </data>
+    <data name="SdrSettingsViewModel_Description" xml:space="preserve">
+        <value>In this section, you can configure various SDR parameters.</value>
+    </data>
+    <data name="SdrSettingsViewModel_DefaultFreqs_Title" xml:space="preserve">
+        <value>Default frequencies</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorFreq_Description" xml:space="preserve">
+        <value>In this section you can configure the default VOR frequency.</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorFreq_Header" xml:space="preserve">
+        <value>VOR frequency</value>
+    </data>
+    <data name="SdrSettingsViewModel_LLzFreq_Description" xml:space="preserve">
+        <value>In this section you can configure the default LLZ frequency.</value>
+    </data>
+    <data name="SdrSettingsViewModel_LlzFreq_Header" xml:space="preserve">
+        <value>LLZ frequency</value>
+    </data>
+    <data name="SdrSettingsViewModel_GpFreq_Description" xml:space="preserve">
+        <value>In this section you can configure the default GP frequency.</value>
+    </data>
+    <data name="SdrSettingsViewModel_GpFreq_Header" xml:space="preserve">
+        <value>GP frequency</value>
+    </data>
+    <data name="SdrSettingsViewModel_DataThinning_Description" xml:space="preserve">
+        <value>In this section you can configure the default data thinning frequency.</value>
+    </data>
+    <data name="SdrSettingsViewModel_DataThinning_Header" xml:space="preserve">
+        <value>Data thinning</value>
+    </data>
+    <data name="SdrSettingsViewModel_FileWriteFreq_Description" xml:space="preserve">
+        <value>In this section you can configure the default frequency of writing to file.</value>
+    </data>
+    <data name="SdrSettingsViewModel_FileWriteFreq_Header" xml:space="preserve">
+        <value>Frequency of writing to file</value>
+    </data>
+    <data name="SdrSettingsViewModel_DefaultChannels_Title" xml:space="preserve">
+        <value>Default channels</value>
+    </data>
+    <data name="SdrSettingsViewModel_LlzChannel_Header" xml:space="preserve">
+        <value>LLZ channel</value>
+    </data>
+    <data name="SdrSettingsViewModel_LLzChannel_Description" xml:space="preserve">
+        <value>In this section you can configure the default LLZ channel.</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorChannel_Description" xml:space="preserve">
+        <value>In this section you can configure the default VOR channel.</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorChannel_Header" xml:space="preserve">
+        <value>VOR channel</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Sdr/RS.ru.resx
@@ -239,4 +239,58 @@
     <data name="RecordStartView_RecordTags_Title" xml:space="preserve">
         <value>Теги записи (опционально)</value>
     </data>
+    <data name="SdrSettingsViewModel_Header" xml:space="preserve">
+        <value>Настройки SDR</value>
+    </data>
+    <data name="SdrSettingsViewModel_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить различные параметры SDR.</value>
+    </data>
+    <data name="SdrSettingsViewModel_DefaultFreqs_Title" xml:space="preserve">
+        <value>Частоты по умолчанию</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorFreq_Header" xml:space="preserve">
+        <value>Частота VOR</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorFreq_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить частоту VOR по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_LlzFreq_Header" xml:space="preserve">
+        <value>Частота LLZ</value>
+    </data>
+    <data name="SdrSettingsViewModel_LLzFreq_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить частоту LLZ по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_GpFreq_Header" xml:space="preserve">
+        <value>Частота GP</value>
+    </data>
+    <data name="SdrSettingsViewModel_GpFreq_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить частоту GP по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_DataThinning_Header" xml:space="preserve">
+        <value>Прореживание данных</value>
+    </data>
+    <data name="SdrSettingsViewModel_DataThinning_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить частоту прореживания данных по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_FileWriteFreq_Header" xml:space="preserve">
+        <value>Частота записи в файл</value>
+    </data>
+    <data name="SdrSettingsViewModel_FileWriteFreq_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить частоту записи в файл по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_DefaultChannels_Title" xml:space="preserve">
+        <value>Каналы по умолчанию</value>
+    </data>
+    <data name="SdrSettingsViewModel_LLzChannel_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить канал LLZ по умолчанию.</value>
+    </data>
+    <data name="SdrSettingsViewModel_LlzChannel_Header" xml:space="preserve">
+        <value>Канал LLZ</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorChannel_Header" xml:space="preserve">
+        <value>Канал VOR</value>
+    </data>
+    <data name="SdrSettingsViewModel_VorChannel_Description" xml:space="preserve">
+        <value>В этом разделе можно настроить канал VOR по умолчанию.</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/FlightSdrViewModel.cs
@@ -21,12 +21,15 @@ namespace Asv.Drones.Gui.Sdr;
 
 public class FlightSdrViewModelConfig
 {
-    public string GpFrequencyInMhz { get; set; }
-    public string LlzFrequencyInMhz { get; set; }
-    public string VorFrequencyInMhz { get; set; }
-    
+    public string GpFrequencyInMhz { get; set; } = "108";
+    public string LlzFrequencyInMhz { get; set; } = "108";
+    public string VorFrequencyInMhz { get; set; } = "108";
+
     public string LlzChannel { get; set; }
     public string VorChannel { get; set; }
+
+    public float WriteFrequency { get; set; } = 5;
+    public uint ThinningFrequency { get; set; } = 5;
 }
 
 public class FlightSdrViewModel:FlightSdrWidgetBase
@@ -152,8 +155,8 @@ public class FlightSdrViewModel:FlightSdrWidgetBase
                     break;
             }
             _configuration.Set(_config);
-            return Payload.Sdr.SetModeAndCheckResult(SelectedMode.Mode,
-                (ulong)Math.Round(_freqInMHzMeasureUnit.ConvertToSi(FrequencyInMhz)), 5, 5, cancel);
+               return Payload.Sdr.SetModeAndCheckResult(SelectedMode.Mode,
+                (ulong)Math.Round(_freqInMHzMeasureUnit.ConvertToSi(FrequencyInMhz)), _config.WriteFrequency, _config.ThinningFrequency, cancel);
         });
         UpdateMode.ThrownExceptions.Subscribe(ex =>
         {

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsView.axaml
@@ -1,0 +1,111 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:core="clr-namespace:Asv.Drones.Gui.Core;assembly=Asv.Drones.Gui.Core"
+             xmlns:sdr="clr-namespace:Asv.Drones.Gui.Sdr"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Asv.Drones.Gui.Sdr.SdrSettingsView"
+             x:CompileBindings="True"
+             x:DataType="sdr:SdrSettingsViewModel">
+    <Design.DataContext>
+        <sdr:SdrSettingsViewModel/>
+    </Design.DataContext>
+    <core:OptionsDisplayItem Header="{x:Static sdr:RS.SdrSettingsViewModel_Header}" 
+                             Description="{x:Static sdr:RS.SdrSettingsViewModel_Description}"
+                             Expands="True"
+                             IsExpanded="False"
+                             Icon="M338,541 C338,542.104 337.104,543 336,543 L312,543 C310.896,543 310,542.104 310,541 L310,527 C310,525.896 310.896,525 312,525 L336,525 C337.104,525 338,525.896 338,527 L338,541 L338,541 Z M336,523 L333.9,523 L323.366,517.12 C322.888,516.854 322.276,517.013 322,517.472 C321.724,517.931 321.888,518.518 322.366,518.783 L329.975,523 L312,523 C309.791,523 308,524.791 308,527 L308,541 C308,543.209 309.791,545 312,545 L336,545 C338.209,545 340,543.209 340,541 L340,527 C340,524.791 338.209,523 336,523 L336,523 Z M329,538 C326.791,538 325,536.209 325,534 C325,531.791 326.791,530 329,530 C331.209,530 333,531.791 333,534 C333,536.209 331.209,538 329,538 L329,538 Z M329,528 C325.687,528 323,530.687 323,534 C323,537.314 325.687,540 329,540 C332.313,540 335,537.314 335,534 C335,530.687 332.313,528 329,528 L329,528 Z M319,533 L313,533 C312.447,533 312,533.447 312,534 C312,534.553 312.447,535 313,535 L319,535 C319.553,535 320,534.553 320,534 C320,533.447 319.553,533 319,533 L319,533 Z M319,537 L313,537 C312.447,537 312,537.448 312,538 C312,538.553 312.447,539 313,539 L319,539 C319.553,539 320,538.553 320,538 C320,537.448 319.553,537 319,537 L319,537 Z M319,529 L313,529 C312.447,529 312,529.447 312,530 C312,530.553 312.447,531 313,531 L319,531 C319.553,531 320,530.553 320,530 C320,529.447 319.553,529 319,529 L319,529 Z"
+                             >
+        <core:OptionsDisplayItem.Content>
+                <StackPanel>
+                    
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_FileWriteFreq_Header}"
+                                             Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_FileWriteFreq_Description}">
+                        
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding WriteFrequency}" Width="120">
+                                <TextBox.InnerRightContent>
+                                    <TextBlock Text="{CompiledBinding HzFrequencyUnits}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="4"/>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_DataThinning_Header}"
+                                             Icon="M3 4.6C3 4.03995 3 3.75992 3.10899 3.54601C3.20487 3.35785 3.35785 3.20487 3.54601 3.10899C3.75992 3 4.03995 3 4.6 3H19.4C19.9601 3 20.2401 3 20.454 3.10899C20.6422 3.20487 20.7951 3.35785 20.891 3.54601C21 3.75992 21 4.03995 21 4.6V6.33726C21 6.58185 21 6.70414 20.9724 6.81923C20.9479 6.92127 20.9075 7.01881 20.8526 7.10828C20.7908 7.2092 20.7043 7.29568 20.5314 7.46863L14.4686 13.5314C14.2957 13.7043 14.2092 13.7908 14.1474 13.8917C14.0925 13.9812 14.0521 14.0787 14.0276 14.1808C14 14.2959 14 14.4182 14 14.6627V17L10 21V14.6627C10 14.4182 10 14.2959 9.97237 14.1808C9.94787 14.0787 9.90747 13.9812 9.85264 13.8917C9.7908 13.7908 9.70432 13.7043 9.53137 13.5314L3.46863 7.46863C3.29568 7.29568 3.2092 7.2092 3.14736 7.10828C3.09253 7.01881 3.05213 6.92127 3.02763 6.81923C3 6.70414 3 6.58185 3 6.33726V4.6Z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_DataThinning_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding ThinningFrequency}" Width="120">
+                                <TextBox.InnerRightContent>
+                                    <TextBlock Text="{CompiledBinding HzFrequencyUnits}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="4"/>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <TextBlock Margin="4 0 0 8" FontSize="16" FontWeight="SemiBold" Text="{x:Static sdr:RS.SdrSettingsViewModel_DefaultFreqs_Title}"/>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_GpFreq_Header}"
+                                             Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_GpFreq_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding GpFrequencyInMhz}" Width="120">
+                                <TextBox.InnerRightContent>
+                                    <TextBlock Text="{CompiledBinding MHzFrequencyUnits}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="4"/>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_LlzFreq_Header}"
+                                             Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_LLzFreq_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding LlzFrequencyInMhz}" Width="120">
+                                <TextBox.InnerRightContent>
+                                    <TextBlock Text="{CompiledBinding MHzFrequencyUnits}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="4"/>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_VorFreq_Header}"
+                                             Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_VorFreq_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding VorFrequencyInMhz}" Width="120">
+                                <TextBox.InnerRightContent>
+                                    <TextBlock Text="{CompiledBinding MHzFrequencyUnits}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="4"/>
+                                </TextBox.InnerRightContent>
+                            </TextBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <TextBlock Margin="4 0 0 8" FontSize="16" FontWeight="SemiBold" Text="{x:Static sdr:RS.SdrSettingsViewModel_DefaultChannels_Title}"/>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_LlzChannel_Header}"
+                                                                 Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                                                 Description="{x:Static sdr:RS.SdrSettingsViewModel_LLzChannel_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding LlzChannel}" Width="120"/>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static sdr:RS.SdrSettingsViewModel_VorChannel_Header}"
+                                             Icon="M24.104,41.577c-0.025,0-0.053-0.001-0.078-0.001c-1.093-0.035-2.025-0.802-2.271-1.867l-5.46-23.659l-3.199,8.316 c-0.357,0.93-1.252,1.544-2.249,1.544H2.41c-1.331,0-2.41-1.079-2.41-2.41c0-1.331,1.079-2.41,2.41-2.41h6.78l5.433-14.122 c0.38-0.989,1.351-1.612,2.418-1.54c1.057,0.074,1.941,0.831,2.18,1.863l5.186,22.474l4.618-15.394 c0.276-0.923,1.078-1.592,2.035-1.702c0.953-0.107,1.889,0.36,2.365,1.198l4.127,7.222h7.037c1.331,0,2.41,1.079,2.41,2.41 c0,1.331-1.079,2.41-2.41,2.41h-8.436c-0.865,0-1.666-0.463-2.094-1.214l-2.033-3.559l-5.616,18.722 C26.104,40.88,25.164,41.577,24.104,41.577z"
+                                             Description="{x:Static sdr:RS.SdrSettingsViewModel_VorChannel_Description}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <TextBox Text="{CompiledBinding VorChannel}" Width="120"/>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
+                </StackPanel>
+            </core:OptionsDisplayItem.Content>
+    </core:OptionsDisplayItem>
+</UserControl>

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsView.axaml.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsView.axaml.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.Composition;
+using Asv.Drones.Gui.Core;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
+
+namespace Asv.Drones.Gui.Sdr;
+
+[ExportView(typeof(SdrSettingsViewModel))]
+[PartCreationPolicy(CreationPolicy.NonShared)]
+public partial class SdrSettingsView : ReactiveUserControl<SdrSettingsViewModel>
+{
+    public SdrSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Settings/Sdr/SdrSettingsViewModel.cs
@@ -1,0 +1,117 @@
+﻿using System.ComponentModel.Composition;
+using System.Windows.Input;
+using Asv.Avalonia.Map;
+using Asv.Cfg;
+using Asv.Common;
+using Asv.Drones.Gui.Core;
+using DynamicData.Binding;
+using Material.Icons;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace Asv.Drones.Gui.Sdr;
+
+[Export(typeof(ISettingsPart))]
+[PartCreationPolicy(CreationPolicy.NonShared)]
+public class SdrSettingsViewModel : SettingsPartBase
+{
+    private static readonly Uri Uri = new(SettingsPartBase.Uri, "sdr");
+
+    private FlightSdrViewModelConfig _config; 
+    
+    private readonly IConfiguration _cfg;
+    private readonly ILocalizationService _loc;
+    
+    private readonly IMeasureUnitItem<double, FrequencyUnits> _freqUnitInHz;
+    private readonly IMeasureUnitItem<double, FrequencyUnits> _freqUnitInMHz;
+
+    public SdrSettingsViewModel() : base(Uri)
+    {
+        HzFrequencyUnits = "Hz";
+        MHzFrequencyUnits = "MHz";
+        
+        WriteFrequency = 5;
+        ThinningFrequency = 5;
+        
+        GpFrequencyInMhz = "108";
+        LlzFrequencyInMhz = "108";
+        VorFrequencyInMhz = "108";
+
+        LlzChannel = "18X";
+        VorChannel = "17X";
+    }
+
+    [ImportingConstructor]
+    public SdrSettingsViewModel(IConfiguration cfg, ILocalizationService loc) : this()
+    {
+        _cfg = cfg;
+        _loc = loc;
+
+        _config = _cfg.Get<FlightSdrViewModelConfig>();
+
+        WriteFrequency = _config.WriteFrequency;
+        ThinningFrequency = _config.ThinningFrequency;
+        GpFrequencyInMhz = _config.GpFrequencyInMhz;
+        LlzFrequencyInMhz = _config.LlzFrequencyInMhz;
+        VorFrequencyInMhz = _config.VorFrequencyInMhz;
+        LlzChannel = _config.LlzChannel;
+        VorChannel = _config.VorChannel;
+        
+        _freqUnitInHz = _loc.Frequency.AvailableUnits.FirstOrDefault(_ => _.Id == FrequencyUnits.Hz);
+        _freqUnitInMHz = _loc.Frequency.AvailableUnits.FirstOrDefault(_ => _.Id == FrequencyUnits.MHz);
+
+        HzFrequencyUnits = _freqUnitInHz?.Unit;
+        MHzFrequencyUnits = _freqUnitInMHz?.Unit;
+        
+        this.WhenAnyPropertyChanged(nameof(WriteFrequency),
+                nameof(ThinningFrequency),
+                nameof(GpFrequencyInMhz),
+                nameof(LlzFrequencyInMhz),
+                nameof(VorFrequencyInMhz),
+                nameof(LlzChannel),
+                nameof(VorChannel))
+            .Subscribe(_ =>
+            {
+                _config.WriteFrequency = WriteFrequency;
+                _config.ThinningFrequency = ThinningFrequency;
+                _config.GpFrequencyInMhz = GpFrequencyInMhz;
+                _config.LlzFrequencyInMhz = LlzFrequencyInMhz;
+                _config.VorFrequencyInMhz = VorFrequencyInMhz;
+                _config.LlzChannel = LlzChannel;
+                _config.VorChannel = VorChannel;
+                
+                _cfg.Set(_config);
+            })
+            .DisposeItWith(Disposable);
+    }
+
+    [Reactive]
+    public string HzFrequencyUnits { get; set; }
+
+    [Reactive]
+    public string MHzFrequencyUnits { get; set; }
+
+    [Reactive]
+    public float WriteFrequency { get; set; }
+    
+    [Reactive]
+    public uint ThinningFrequency { get; set; }
+    
+    [Reactive]
+    public string GpFrequencyInMhz { get; set; }
+
+    [Reactive]
+    public string LlzFrequencyInMhz { get; set; }
+    
+    [Reactive]
+    public string VorFrequencyInMhz { get; set; }
+
+    [Reactive]
+    public string LlzChannel { get; set; }
+
+    [Reactive]
+    public string VorChannel { get; set; }
+
+    public override int Order => 3;
+
+}


### PR DESCRIPTION
Created a new settings section for Software-Defined Radio (SDR) configurations. This update includes the introduction of configurable default frequencies and channels for SDR components. Frequency configurations are provided for VOR, LLZ, and GP, each with the option to set a default channel. Adjustable file write frequency and data thinning settings have also been introduced. This enhancement allows users to set and alter SDR parameters according to their preference and specific requirements.

Asana: https://app.asana.com/0/1203851531040615/1203719678217439/f