### PR TITLE
feat: add anchor-menu support to map page

### DIFF
--- a/src/Asv.Drones.Gui.Core/Controls/MaterialIconConverter.cs
+++ b/src/Asv.Drones.Gui.Core/Controls/MaterialIconConverter.cs
@@ -2,10 +2,11 @@ using System.Globalization;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 using Material.Icons;
+using Material.Icons.Avalonia;
 
 namespace Asv.Drones.Gui.Core
 {
-    public class MaterialIconConverter:IValueConverter
+    public class MaterialIconConverter : IValueConverter
     {
         public static IValueConverter  Instance { get; } = new MaterialIconConverter();
         
@@ -13,21 +14,18 @@ namespace Asv.Drones.Gui.Core
         {
             if (value is MaterialIconKind kind)
             {
-                return new DrawingImage
+                return new MaterialIcon
                 {
-                    Drawing = new GeometryDrawing
-                    {
-                        Geometry = PathGeometry.Parse(MaterialIconDataProvider.GetData(kind))
-                    }
+                    Kind = kind
                 };
             }
 
-            return null;
+            return new MaterialIcon();
         }
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
+        { 
+            return value;
         }
     }
 }

--- a/src/Asv.Drones.Gui.Core/Controls/MaterialIconConverter.cs
+++ b/src/Asv.Drones.Gui.Core/Controls/MaterialIconConverter.cs
@@ -8,7 +8,7 @@ namespace Asv.Drones.Gui.Core
 {
     public class MaterialIconConverter : IValueConverter
     {
-        public static IValueConverter  Instance { get; } = new MaterialIconConverter();
+        public static IValueConverter Instance { get; } = new MaterialIconConverter();
         
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {

--- a/src/Asv.Drones.Gui.Core/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Core/RS.Designer.cs
@@ -1014,6 +1014,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Anchors.
+        /// </summary>
+        public static string HeaderAnchorsMenu_Title {
+            get {
+                return ResourceManager.GetString("HeaderAnchorsMenu_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Coordinates calculator.
         /// </summary>
         public static string HeaderCoordinatesCalculatorMenu_Header {

--- a/src/Asv.Drones.Gui.Core/RS.resx
+++ b/src/Asv.Drones.Gui.Core/RS.resx
@@ -992,4 +992,7 @@
   <data name="FieldStrength_MicroVoltsPerMeter_Unit" xml:space="preserve">
     <value>µV/m</value>
   </data>
+  <data name="HeaderAnchorsMenu_Title" xml:space="preserve">
+    <value>Anchors</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Core/RS.ru.resx
@@ -1015,4 +1015,7 @@
   <data name="FieldStrength_MicroVoltsPerMeter_Unit" xml:space="preserve">
 	  <value>мкВ/м</value>
   </data>
+  <data name="HeaderAnchorsMenu_Title" xml:space="preserve">
+	  <value>Якори</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/HeaderMenuItem.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/HeaderMenuItem.cs
@@ -14,23 +14,24 @@ namespace Asv.Drones.Gui.Core
         {
             
         }
+        
         [Reactive]
         public int Order { get; set; }
         [Reactive]
-        public MaterialIconKind Icon { get;set; }
+        public MaterialIconKind Icon { get; set; }
         [Reactive]
-        public string Header { get;set; }
+        public string Header { get; set; }
         [Reactive]
-        public ICommand Command { get;set; }
+        public ICommand Command { get; set; }
         [Reactive]
-        public object? CommandParameter { get;set; }
+        public object? CommandParameter { get; set; }
         [Reactive]
-        public bool IsVisible { get;set; } = true;
+        public bool IsVisible { get; set; } = true;
         [Reactive]
-        public bool StaysOpenOnClick { get;set; }
-
-        [Reactive] public bool IsEnabled { get; set; } = true;
-        public virtual ReadOnlyObservableCollection<IHeaderMenuItem>? Items { get; }
+        public bool StaysOpenOnClick { get; set; }
+        [Reactive] 
+        public bool IsEnabled { get; set; } = true;
+        public virtual ReadOnlyObservableCollection<IHeaderMenuItem>? Items { get; set; }
         [Reactive]
         public KeyGesture? HotKey { get; set; }
     }

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/IHeaderMenuItem.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/IHeaderMenuItem.cs
@@ -14,7 +14,7 @@ namespace Asv.Drones.Gui.Core
         object? CommandParameter { get; }
         bool IsVisible { get; }
         bool StaysOpenOnClick { get; }
-        ReadOnlyObservableCollection<IHeaderMenuItem>? Items { get; }
+        ReadOnlyObservableCollection<IHeaderMenuItem>? Items { get; set; }
         public bool IsEnabled { get; }
         public KeyGesture? HotKey { get; }
     }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Flight/FlightPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Flight/FlightPageViewModel.cs
@@ -22,9 +22,10 @@ namespace Asv.Drones.Gui.Core
         
         [ImportingConstructor]
         public FlightPageViewModel( IMapService map, IConfiguration cfg,
+            [ImportMany(HeaderMenuItem.UriString)]IEnumerable<IHeaderMenuItem> exportedMenuItems,
             [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAnchor>> markers,
             [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapWidget>> widgets,
-            [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAction>> actions):base(Uri,map,markers,widgets,actions)
+            [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAction>> actions):base(Uri,map,exportedMenuItems,markers,widgets,actions)
         {
             Title = RS.FlightShellMenuItem_Name;
             Icon = MaterialIconKind.Map;

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/HeaderAnchorsMenu.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/HeaderAnchorsMenu.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Reactive.Linq;
 using Asv.Common;
 using Material.Icons;
 using ReactiveUI;
@@ -14,12 +13,11 @@ public class HeaderAnchorsMenu : HeaderMenuItem
 {
     public const string UriString = HeaderMenuItem.UriString + "/anchors";
     public static readonly Uri Uri = new(UriString);
-    private readonly ReadOnlyObservableCollection<IHeaderMenuItem> _items;
 
     [ImportingConstructor]
     public HeaderAnchorsMenu() : base(Uri)
     {
-        Header = "Anchors";
+        Header = RS.HeaderAnchorsMenu_Title;
         Icon = MaterialIconKind.Anchor;
         Order = short.MinValue;
 

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/HeaderAnchorsMenu.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/HeaderAnchorsMenu.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using System.Reactive.Linq;
+using Asv.Common;
+using Material.Icons;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace Asv.Drones.Gui.Core;
+
+[Export(HeaderMenuItem.UriString, typeof(IHeaderMenuItem))]
+[PartCreationPolicy(CreationPolicy.Shared)]
+public class HeaderAnchorsMenu : HeaderMenuItem
+{
+    public const string UriString = HeaderMenuItem.UriString + "/anchors";
+    public static readonly Uri Uri = new(UriString);
+    private readonly ReadOnlyObservableCollection<IHeaderMenuItem> _items;
+
+    [ImportingConstructor]
+    public HeaderAnchorsMenu() : base(Uri)
+    {
+        Header = "Anchors";
+        Icon = MaterialIconKind.Anchor;
+        Order = short.MinValue;
+
+        this.WhenAnyValue(_ => _.Items)
+            .Subscribe(_ => IsVisible = _ != null)
+            .DisposeItWith(Disposable);
+    }
+
+    [Reactive]
+    public override ReadOnlyObservableCollection<IHeaderMenuItem>? Items { get; set; }
+}

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
@@ -152,7 +152,8 @@ namespace Asv.Drones.Gui.Core
            
             Disposable.AddAction(() =>
             {
-                menuItem.Items = null;
+                if (menuItem != null) 
+                    menuItem.Items = null;
                 _disposableMapUpdate?.Dispose();
             });
         }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/Planing/PlaningPageViewModel.cs
@@ -22,9 +22,10 @@ namespace Asv.Drones.Gui.Core
         
         [ImportingConstructor]
         public PlaningPageViewModel( IMapService map, IConfiguration cfg, 
+            [ImportMany(HeaderMenuItem.UriString)]IEnumerable<IHeaderMenuItem> exportedMenuItems,
             [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAnchor>> markers,
             [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapWidget>> widgets,
-            [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAction>> actions):base(Uri,map,markers,widgets,actions)
+            [ImportMany(UriString)] IEnumerable<IViewModelProvider<IMapAction>> actions):base(Uri,map,exportedMenuItems,markers,widgets,actions)
         {
             Title = RS.PlaningShellMenuItem_Name;
             Icon = MaterialIconKind.MapMarkerCheck;


### PR DESCRIPTION
This commit introduces a major change to the map page. A URI string is defined and a new constructor is added to the MapPageViewModel to take in a collection of IHeaderMenuItem. A transformation is added to the 'Markers' collection. This allows each IHeaderMenuItem to have its command linked to a map location, essentially adding support for an 'anchor' menu. An instance of 'HeaderAnchorsMenu' is sourced from the collection. If found, its items are set to the transformed collection.

A similar modification is made to PlaningPageViewModel, FlightPageViewModel - an exportedMenuItems parameter is added and passed on to super constructor. This ensures anchor menu support is uniform across these classes.

A new class HeaderAnchorsMenu is introduced. It exports itself as IHeaderMenuItem and has an observable collection of IHeaderMenuItem, which gets its visibility set based on if Items is null or not.

The commit also loosens the encapsulation around IHeaderMenuItem Items property to allow its mutation. This allows for the addition/removal of menu-items dynamically during program's execution. This was necessary to enable the dynamic anchor-menu functionality.

Asana: https://app.asana.com/0/1203851531040615/1203719678217443/f