### PR TITLE
fix: update AsvMavlinkVersion and enhance RefreshImpl function

### DIFF
--- a/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreViewModel.cs
@@ -309,7 +309,7 @@ public abstract class HierarchicalStoreViewModel<TKey,TFile>:HierarchicalStoreVi
 
     protected override void RefreshImpl()
     {
-        _source.Clear();    
+        _source.Clear();
         _source.AddOrUpdate(_store.GetEntries());
     }
 

--- a/src/Asv.Drones.Gui.Custom.props
+++ b/src/Asv.Drones.Gui.Custom.props
@@ -7,7 +7,7 @@
     <ProductVersion>0.1.0</ProductVersion>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
     <AsvCommonVersion>1.12.5</AsvCommonVersion>
-    <AsvMavlinkVersion>3.4.2-alpha10</AsvMavlinkVersion>
+    <AsvMavlinkVersion>3.4.2-alpha11</AsvMavlinkVersion>
     <FluentAvaloniaUIVersion>2.0.0</FluentAvaloniaUIVersion>
     <ReactiveUIVersion>19.3.3</ReactiveUIVersion>
     <MaterialIconsAvaloniaVersion>2.0.1</MaterialIconsAvaloniaVersion>

--- a/src/Asv.Drones.Gui.Sdr/Control/SdrStoreBrowserViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrStoreBrowserViewModel.cs
@@ -38,7 +38,15 @@ public class SdrStoreBrowserViewModel:HierarchicalStoreViewModel<Guid,IListDataF
         var metadata = file.File.ReadMetadata();
         return SdrTagViewModelHelper.ConvertToTag(metadata).ToImmutableArray();
     }
-
+    
+    protected override void RefreshImpl()
+    {
+        if (_svc.Store is FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>> fileStore)
+        {
+            fileStore.UpdateEntries();
+        }
+        base.RefreshImpl();
+    }
 
     public ILocalizationService Localization => _loc;
 }


### PR DESCRIPTION
This commit updates the AsvMavlinkVersion to 3.4.2-alpha11 in Asv.Drones.Gui.Custom.props. Moreover, additional functionality has been added to the RefreshImpl () method of SdrStoreBrowserViewModel.cs to provide an UpdateEntries() condition for fileStore. It ensures updated records are fetched from the store during the refresh process. Also, a minor edit has been made to HierarchicalStoreViewModel.cs to maintain code cleanliness.

Asana: https://app.asana.com/0/1203851531040615/1205758515944602/f