### PR TITLE
feat: added unit option for drone bearing measurement

### DIFF
--- a/src/Asv.Drones.Gui.Core/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Core/RS.Designer.cs
@@ -789,6 +789,15 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [D]°[M]′.
+        /// </summary>
+        public static string Degrees_DM_Title {
+            get {
+                return ResourceManager.GetString("Degrees_DM_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [D]°[M]′[S]′′.
         /// </summary>
         public static string Degrees_DMS_Title {
@@ -1671,11 +1680,29 @@ namespace Asv.Drones.Gui.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Change the current measure units of angle.
+        ///   Looks up a localized string similar to Change the current measure units of angle..
         /// </summary>
         public static string MeasureUnitsSettingsViewModelAngleDescription {
             get {
                 return ResourceManager.GetString("MeasureUnitsSettingsViewModelAngleDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bearing.
+        /// </summary>
+        public static string MeasureUnitsSettingsViewModelBearing {
+            get {
+                return ResourceManager.GetString("MeasureUnitsSettingsViewModelBearing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change the current measure units of bearing..
+        /// </summary>
+        public static string MeasureUnitsSettingsViewModelBearingDescription {
+            get {
+                return ResourceManager.GetString("MeasureUnitsSettingsViewModelBearingDescription", resourceCulture);
             }
         }
         

--- a/src/Asv.Drones.Gui.Core/RS.resx
+++ b/src/Asv.Drones.Gui.Core/RS.resx
@@ -786,7 +786,7 @@
     <value>Angle</value>
   </data>
   <data name="MeasureUnitsSettingsViewModelAngleDescription" xml:space="preserve">
-    <value>Change the current measure units of angle</value>
+    <value>Change the current measure units of angle.</value>
   </data>
   <data name="Degrees_Degree_Title" xml:space="preserve">
     <value>[D]°</value>
@@ -991,5 +991,14 @@
   </data>
   <data name="FieldStrength_MicroVoltsPerMeter_Unit" xml:space="preserve">
     <value>µV/m</value>
+  </data>
+  <data name="Degrees_DM_Title" xml:space="preserve">
+    <value>[D]°[M]′</value>
+  </data>
+  <data name="MeasureUnitsSettingsViewModelBearing" xml:space="preserve">
+    <value>Bearing</value>
+  </data>
+  <data name="MeasureUnitsSettingsViewModelBearingDescription" xml:space="preserve">
+    <value>Change the current measure units of bearing.</value>
   </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Core/RS.ru.resx
@@ -1015,4 +1015,13 @@
   <data name="FieldStrength_MicroVoltsPerMeter_Unit" xml:space="preserve">
 	  <value>мкВ/м</value>
   </data>
+  <data name="Degrees_DM_Title" xml:space="preserve">
+	  <value>[Г]°[М]′</value>
+  </data>
+  <data name="MeasureUnitsSettingsViewModelBearing" xml:space="preserve">
+	  <value>Азимут</value>
+  </data>
+  <data name="MeasureUnitsSettingsViewModelBearingDescription" xml:space="preserve">
+	  <value>Измените текущие единицы измерения азимута.</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Bearing.cs
+++ b/src/Asv.Drones.Gui.Core/Services/Localization/MeasureUnits/Bearing.cs
@@ -1,15 +1,18 @@
 using Asv.Cfg;
+using Asv.Common;
 
 namespace Asv.Drones.Gui.Core;
 
 public enum BearingUnits
 {
-    Degree
+    Degree,
+    DegreesMinutes
 }
 public class Bearing : MeasureUnitBase<double,BearingUnits>
 {
     private static readonly IMeasureUnitItem<double, BearingUnits>[] _units = {
-        new DoubleMeasureUnitItem<BearingUnits>(BearingUnits.Degree,RS.BearingDegreeTitle,"°",true,"F2",1)
+        new DoubleMeasureUnitItem<BearingUnits>(BearingUnits.Degree,RS.BearingDegreeTitle,"°",true,"F2",1),
+        new DmMeasureUnit()
     };
     
     public Bearing(IConfiguration cfgSvc, string cfgKey) : base(cfgSvc, cfgKey, _units)
@@ -19,4 +22,48 @@ public class Bearing : MeasureUnitBase<double,BearingUnits>
     public override string Title => RS.Bearing_Title;
 
     public override string Description => RS.Bearing_Description;
+}
+
+public class DmMeasureUnit : IMeasureUnitItem<double, BearingUnits>
+{
+    public BearingUnits Id => BearingUnits.DegreesMinutes;
+    public string Title => RS.Degrees_DM_Title;
+    public string Unit => RS.Degrees_DM_Title;
+    public bool IsSiUnit => false;
+    //Not usable
+    public double ConvertFromSi(double siValue)
+    {
+        return siValue;
+    }
+    //Not usable
+    public double ConvertToSi(double value)
+    {
+        return value;
+    }
+
+    public double Parse(string? value)
+    {
+        return value != null && AngleDm.TryParse(value, out var result) ? result : double.NaN;
+    }
+
+    public bool IsValid(string? value)
+    {
+        return value != null && AngleDm.IsValid(value);
+    }
+
+    public string? GetErrorMessage(string? value)
+    {
+        return AngleDm.GetErrorMessage(value);
+    }
+
+    public string Print(double value)
+    {
+        return AngleDm.PrintDm(value);
+    }
+
+    public string PrintWithUnits(double value)
+    {
+        return Print(value);
+    }
+
 }

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/MeasureUnits/MeasureUnitsSettingsView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/MeasureUnits/MeasureUnitsSettingsView.axaml
@@ -163,6 +163,22 @@
                         </core:OptionsDisplayItem.ActionButton>
 
                     </core:OptionsDisplayItem>
+                    <core:OptionsDisplayItem Margin="0,0,0,8" Header="{x:Static core:RS.MeasureUnitsSettingsViewModelBearing}"
+                                             Icon="{Binding AngleIcon}"
+                                             Description="{x:Static core:RS.MeasureUnitsSettingsViewModelBearingDescription}">
+
+                        <core:OptionsDisplayItem.ActionButton>
+                            <ComboBox MinWidth="150" SelectedItem="{Binding SelectedBearingUnit}" 
+                                      ItemsSource="{Binding BearingUnits}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Title}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </core:OptionsDisplayItem.ActionButton>
+
+                    </core:OptionsDisplayItem>
                 </StackPanel>
             </core:OptionsDisplayItem.Content>
         </core:OptionsDisplayItem>

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/MeasureUnits/MeasureUnitsSettingsViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Settings/MeasureUnits/MeasureUnitsSettingsViewModel.cs
@@ -79,6 +79,12 @@ namespace Asv.Drones.Gui.Core
             this.WhenAnyValue(_ => _.SelectedAngleUnit)
                 .Subscribe(_localization.Degree.CurrentUnit)
                 .DisposeItWith(Disposable);
+            
+            _localization.Bearing.CurrentUnit.Subscribe(_ => SelectedBearingUnit = _)
+                .DisposeItWith(Disposable);
+            this.WhenAnyValue(_ => _.SelectedBearingUnit)
+                .Subscribe(_localization.Bearing.CurrentUnit)
+                .DisposeItWith(Disposable);
         }
         
         [Reactive]
@@ -129,5 +135,12 @@ namespace Asv.Drones.Gui.Core
             _localization.Degree.AvailableUnits;
         
         public string AngleIcon => MaterialIconDataProvider.GetData(MaterialIconKind.AngleAcute);
+        
+        [Reactive]
+        public IMeasureUnitItem<double, BearingUnits> SelectedBearingUnit { get; set; }
+        
+        public IEnumerable<IMeasureUnitItem<double, BearingUnits>> BearingUnits => 
+            _localization.Bearing.AvailableUnits;
+        
     }
 }

--- a/src/Asv.Drones.Gui.Core/Shell/ShellViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/ShellViewModel.cs
@@ -151,9 +151,7 @@ namespace Asv.Drones.Gui.Core
             
             _themeService = themeService;
         }
-
         
-
         [Reactive]
         public string Title { get; set; } = null!;
 

--- a/src/Asv.Drones.Gui.Custom.props
+++ b/src/Asv.Drones.Gui.Custom.props
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ProductVersion>0.1.0</ProductVersion>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
-    <AsvCommonVersion>1.12.5</AsvCommonVersion>
+    <AsvCommonVersion>1.12.7</AsvCommonVersion>
     <AsvMavlinkVersion>3.4.2-alpha10</AsvMavlinkVersion>
     <FluentAvaloniaUIVersion>2.0.0</FluentAvaloniaUIVersion>
     <ReactiveUIVersion>19.3.3</ReactiveUIVersion>


### PR DESCRIPTION
Added Degrees and Minutes unit option for drone bearing measurement and associated GUI controls. This change allows users to view and select either Degree or Degrees and Minutes for drone bearing. The GUI changes include the addition of a ComboBox for the selection of bearing unit and update in localization strings to reflect this new option. Also, updated AsvCommonVersion to 1.12.7.

Asana: https://app.asana.com/0/1203851531040615/1205412828145367/f