### PR TITLE
feat (uav): add localization for data loss dialog in parameters page

### DIFF
--- a/src/Asv.Drones.Gui.Uav/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Uav/RS.Designer.cs
@@ -438,6 +438,51 @@ namespace Asv.Drones.Gui.Uav {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string ParamPageViewModel_DataLossDialog_CloseButtonText {
+            get {
+                return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_CloseButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You&apos;re trying to open another menu folder, but you have unsaved changes in the current one. Do you want to save them?.
+        /// </summary>
+        public static string ParamPageViewModel_DataLossDialog_Content {
+            get {
+                return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_Content", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        public static string ParamPageViewModel_DataLossDialog_PrimaryButtonText {
+            get {
+                return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_PrimaryButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t save.
+        /// </summary>
+        public static string ParamPageViewModel_DataLossDialog_SecondaryButtonText {
+            get {
+                return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_SecondaryButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Potential data loss warning.
+        /// </summary>
+        public static string ParamPageViewModel_DataLossDialog_Title {
+            get {
+                return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Advanced setup.
         /// </summary>
         public static string QuickParamsSetupPageView_AdvancedSetupButton_Text {

--- a/src/Asv.Drones.Gui.Uav/RS.resx
+++ b/src/Asv.Drones.Gui.Uav/RS.resx
@@ -336,4 +336,19 @@
   <data name="MissionStatusView_TotalDistance" xml:space="preserve">
     <value>Total: {0}</value>
   </data>
+  <data name="ParamPageViewModel_DataLossDialog_Title" xml:space="preserve">
+    <value>Potential data loss warning</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_Content" xml:space="preserve">
+    <value>You're trying to open another menu folder, but you have unsaved changes in the current one. Do you want to save them?</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_SecondaryButtonText" xml:space="preserve">
+    <value>Don't save</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Uav/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Uav/RS.ru.resx
@@ -342,6 +342,6 @@
     <value>Не сохранять</value>
   </data>
   <data name="ParamPageViewModel_DataLossDialog_Title" xml:space="preserve">
-    <value>Отмена</value>
+    <value>Предупреждение о возможной потере данных</value>
   </data>
 </root>

--- a/src/Asv.Drones.Gui.Uav/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Uav/RS.ru.resx
@@ -329,4 +329,19 @@
   <data name="MissionStatusView_MissionDistance" xml:space="preserve">
     <value>Миссия: {0}</value>
   </data>
+  <data name="ParamPageViewModel_DataLossDialog_CloseButtonText" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_Content" xml:space="preserve">
+    <value>Вы пытаетесь открыть другой пункт меню, но в текущем у вас есть несохраненные изменения. Хотите сохранить их?</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_SecondaryButtonText" xml:space="preserve">
+    <value>Не сохранять</value>
+  </data>
+  <data name="ParamPageViewModel_DataLossDialog_Title" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageViewModel.cs
@@ -214,11 +214,12 @@ public class ParamPageViewModel: ShellPage
         {
             var dialog = new ContentDialog()
             {
-                Content = "There are unsaved changes, do you want to save them?",
+                Title = RS.ParamPageViewModel_DataLossDialog_Title,
+                Content = RS.ParamPageViewModel_DataLossDialog_Content,
                 IsSecondaryButtonEnabled = true,
-                PrimaryButtonText = "Save",
-                SecondaryButtonText = "Don't save",
-                CloseButtonText = "Close"
+                PrimaryButtonText = RS.ParamPageViewModel_DataLossDialog_PrimaryButtonText,
+                SecondaryButtonText = RS.ParamPageViewModel_DataLossDialog_SecondaryButtonText,
+                CloseButtonText = RS.ParamPageViewModel_DataLossDialog_CloseButtonText
             };
             
             var result = await dialog.ShowAsync();


### PR DESCRIPTION
Localization for the dialog that warns users about potential data loss on the parameters page has been added. The content and button texts of the dialog have been moved to resource files, allowing for easier translation and adjustment of the dialog's language. The changes occurred in the RS.Designer.cs, RS.resx, ParamPageViewModel.cs, and RS.ru.resx files.

Asana: https://app.asana.com/0/1203851531040615/1205835806423473/f