### PR TITLE
feat (uav): add Sync status indicator to Params Page

### DIFF
--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageView.axaml
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageView.axaml
@@ -59,6 +59,9 @@
                                 </ToggleButton>
                                 <avalonia:MaterialIcon IsVisible="{Binding IsPinned}" Width="20"
                                                        Margin="10 0 0 0" DockPanel.Dock="Right" Kind="Pin"/>
+                                <avalonia:MaterialIcon IsVisible="{Binding !IsSynced}" Width="20"
+                                                       Margin="10 0 0 0" DockPanel.Dock="Right" Kind="FloppyDisk"
+                                                       Foreground="Green" />
                                 <TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Center" Text="{Binding Name}"/>
                              </DockPanel>    
                         </DataTemplate>

--- a/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Uav/Shell/Pages/Parameters/ParamPageViewModel.cs
@@ -63,6 +63,7 @@ public class ParamPageViewModel: ShellPage
             .Subscribe(_ => FilterPipe.OnNext(item => item.Filter(SearchText, ShowStaredOnly)))
             .DisposeItWith(Disposable);
          _viewedParamsList = new SourceList<ParamItemViewModel>().DisposeItWith(Disposable);
+
          _viewedParamsList.Connect()
              .Bind(out _viewedParams)
              .Subscribe()
@@ -150,6 +151,8 @@ public class ParamPageViewModel: ShellPage
         inputPipe
             .Filter(FilterPipe)
             .SortBy(_ => _.Name)
+            .AutoRefresh(v => v.IsSynced)
+            .Sort(SortExpressionComparer<ParamItemViewModel>.Descending(v => !v.IsSynced))
             .Bind(out var leftItems)
             .Subscribe()
             .DisposeItWith(Disposable);


### PR DESCRIPTION
Updated ParamPageViewModel.cs and ParamPageView.axaml to show a new icon indicating the sync status of a parameter.
This will enhance UX by allowing users to see at a glance whether their drones are in sync or not.

Asana: https://app.asana.com/0/1203851531040615/1205835806423480/f