### PR TITLE
fix (sdr): update data binding in SdrPayloadBrowserView.axaml

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserView.axaml
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserView.axaml
@@ -140,7 +140,7 @@
                                 <Border ToolTip.Tip="Int64" Background="CornflowerBlue" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                     <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
                                         <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>    
+                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding .}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -148,7 +148,7 @@
                                 <Border ToolTip.Tip="UInt64" Background="#FE8256" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                     <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
                                         <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>    
+                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding .}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -156,7 +156,7 @@
                                 <Border ToolTip.Tip="Float64" Background="#ACC865" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                     <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
                                         <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>    
+                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding .}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -164,7 +164,7 @@
                                 <Border ToolTip.Tip="String8" Background="#CD91B6" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                     <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
                                         <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>    
+                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding .}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -172,7 +172,7 @@
                                 <Border ToolTip.Tip="NoType" Background="DarkOrange" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                     <StackPanel Orientation="Horizontal" Spacing="2" Margin="3">
                                         <avalonia:MaterialIcon VerticalAlignment="Center" Foreground="White" DockPanel.Dock="Left" Kind="TagOutline" Width="14" Height="14" />
-                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>    
+                                        <TextBlock FontSize="12" Foreground="White"  Text="{Binding Name}"/>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>

--- a/src/Asv.Drones.Gui.Sdr/Control/TagViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Control/TagViewModel.cs
@@ -114,6 +114,10 @@ public class LongTagViewModel : TagViewModel
         Value = value;
     }
     public long Value { get; set; }
+    public override string ToString()
+    {
+        return $"{Name}:{Value}";
+    }
 }
 
 public class ULongTagViewModel : TagViewModel
@@ -123,6 +127,10 @@ public class ULongTagViewModel : TagViewModel
         Value = value;
     }
     public ulong Value { get; set; }
+    public override string ToString()
+    {
+        return $"{Name}:{Value}";
+    }
 }
 
 public class DoubleTagViewModel : TagViewModel
@@ -132,6 +140,10 @@ public class DoubleTagViewModel : TagViewModel
         Value = value;
     }
     public double Value { get; set; }
+    public override string ToString()
+    {
+        return $"{Name}:{Value}";
+    }
 }
 
 public class StringTagViewModel : TagViewModel
@@ -141,4 +153,8 @@ public class StringTagViewModel : TagViewModel
         Value = value;
     }
     public string Value { get; set; }
+    public override string ToString()
+    {
+        return $"{Name}:{Value}";
+    }
 }


### PR DESCRIPTION
Changed how data is represented in the SdrPayloadBrowserView by updating the data binding in several TextBlock elements from "{Binding Name}" to "{Binding .}", which now references the current object in the data context. This adjustment was implemented to display the more descriptive output generated by the overriden ToString() methods that were added to various model classes in TagViewModel.cs. The ToString() methods now generate a string representing the name and value of each tag, providing additional clarity in the GUI.

Asana: https://app.asana.com/0/1203851531040615/1205906192538453/f