### PR TITLE
fix: update image processing and dimensions in templates

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/Dialog/TemplaterView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/Dialog/TemplaterView.axaml
@@ -6,7 +6,8 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d" Width="550" Height="500"
              x:DataType="core:TemplaterViewModel"
-             x:Class="Asv.Drones.Gui.Core.TemplaterView">
+             x:Class="Asv.Drones.Gui.Core.TemplaterView"
+             x:Name="Root">
     <Design.DataContext>
         <core:TemplaterViewModel/>
     </Design.DataContext>
@@ -30,7 +31,7 @@
                         </DropDownButton.Content>
                         <DropDownButton.Flyout>
                             <MenuFlyout Placement="Bottom">
-                                <MenuItem Command="{CompiledBinding AddStringTag}">
+                                <MenuItem Command="{CompiledBinding AddEmptyStringTag}">
                                     <MenuItem.Header>
                                         <StackPanel Spacing="8" Orientation="Horizontal">
                                             <avalonia:MaterialIcon Kind="CodeString" Foreground="RosyBrown"/>
@@ -38,7 +39,7 @@
                                         </StackPanel>
                                     </MenuItem.Header>
                                 </MenuItem>
-                                <MenuItem Command="{CompiledBinding AddImageTag}">
+                                <MenuItem Command="{CompiledBinding AddEmptyImageTag}">
                                     <MenuItem.Header>
                                         <StackPanel Spacing="8" Orientation="Horizontal">
                                             <avalonia:MaterialIcon Kind="Image" Foreground="SkyBlue"/>

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/Dialog/TemplaterViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/Dialog/TemplaterViewModel.cs
@@ -35,8 +35,8 @@ public class TemplaterViewModel : ViewModelBaseWithValidation
     {
         
         ClearTagsList = ReactiveCommand.Create(ClearTagsListImpl);
-        AddStringTag = ReactiveCommand.Create(AddStringTagImpl);
-        AddImageTag = ReactiveCommand.Create(AddImageTagImpl);
+        AddEmptyStringTag = ReactiveCommand.Create(() => AddStringTag());
+        AddEmptyImageTag = ReactiveCommand.Create(() => AddImageTag());
     }
 
     [ImportingConstructor]
@@ -75,10 +75,10 @@ public class TemplaterViewModel : ViewModelBaseWithValidation
     public ICommand ClearTagsList { get; set; }
     
     [Reactive]
-    public ICommand AddStringTag { get; set; }
+    public ICommand AddEmptyStringTag { get; set; }
     
     [Reactive]
-    public ICommand AddImageTag { get; set; }
+    public ICommand AddEmptyImageTag { get; set; }
     
     [Reactive]
     public string TemplatePath { get; set; }
@@ -86,24 +86,27 @@ public class TemplaterViewModel : ViewModelBaseWithValidation
     [Reactive]
     public string ResultPath { get; set; }
     
+    [Reactive]
+    public bool IsReportPrint { get; set; }
+    
     public ReadOnlyObservableCollection<TagElement> Tags => _tags;
-    
-    private void AddStringTagImpl()
-    {
-        var currentGuid = Guid.NewGuid();
-        _tagsList.Add(new StringTagElement(currentGuid, ReactiveCommand.Create(() =>
-        {
-            _tagsList.Remove(_tags.FirstOrDefault(_ => _.Id == currentGuid));
-        })){Tag = "", Value = ""});
-    }
-    
-    private void AddImageTagImpl()
+
+    public void AddImageTag(string tag = "", string path = "")
     {
         var currentGuid = Guid.NewGuid();
         _tagsList.Add(new ImageTagElement(currentGuid, ReactiveCommand.Create(() =>
         {
             _tagsList.Remove(_tags.FirstOrDefault(_ => _.Id == currentGuid));
-        })){Tag = "", Path = ""});
+        })){Tag = tag, Path = path});
+    }
+    
+    public void AddStringTag(string tag = "", string value = "")
+    {
+        var currentGuid = Guid.NewGuid();
+        _tagsList.Add(new StringTagElement(currentGuid, ReactiveCommand.Create(() =>
+        {
+            _tagsList.Remove(_tags.FirstOrDefault(_ => _.Id == currentGuid));
+        })){Tag = tag, Value = value});
     }
     
     private void ClearTagsListImpl()
@@ -125,7 +128,7 @@ public class TemplaterViewModel : ViewModelBaseWithValidation
             }
             else if (tag is ImageTagElement imgTag)
             {
-                template.Image(imgTag.Tag, imgTag.Path, 1, 1);
+                template.Image(imgTag.Tag, imgTag.Path);
             }
         }
         

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/DocxTemplate.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/DocxTemplate.cs
@@ -6,7 +6,7 @@ using DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Vml;
 using DocumentFormat.OpenXml.Wordprocessing;
-
+using SkiaSharp;
 using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
 
@@ -81,15 +81,22 @@ public class DocxTemplate : IDocxTemplate
     /// <param name="imgFileName">path to image</param>
     /// <param name="width"></param>
     /// <param name="height"></param>
-    public void Image(string tag, string imgFileName, double width, double height)
+    public void Image(string tag, string imgFileName)
     {
         var mainPart = _document.MainDocumentPart;
         var imagePart = mainPart.AddImagePart(ImagePartType.Png);
+        
         using (var stream = new FileStream(imgFileName, FileMode.Open))
         {
             imagePart.FeedData(stream);
         }
-        AddImageToBody(_document, mainPart.GetIdOfPart(imagePart), tag, ImagePartType.Png, width, height);
+        using(var stream = new FileStream(imgFileName, FileMode.Open))
+        using (SKManagedStream skStream = new SKManagedStream(stream))
+        using (SKBitmap skBitmap = SKBitmap.Decode(skStream))
+        {
+            AddImageToBody(_document, mainPart.GetIdOfPart(imagePart), tag, ImagePartType.Png, skBitmap.Width, skBitmap.Height);
+        }
+       
     }
 
     /// <summary>
@@ -100,12 +107,16 @@ public class DocxTemplate : IDocxTemplate
     /// <param name="imageStream">image stream</param>
     /// <param name="width"></param>
     /// <param name="height"></param>
-    public void Image(string tag, MemoryStream imageStream, double width, double height)
+    public void Image(string tag, MemoryStream imageStream)
     {
         var mainPart = _document.MainDocumentPart;
         var imagePart = mainPart.AddImagePart(ImagePartType.Png);
         imagePart.FeedData(imageStream);
-        AddImageToBody(_document, mainPart.GetIdOfPart(imagePart), tag, ImagePartType.Png, width, height);
+        using (SKManagedStream skStream = new SKManagedStream(imageStream))
+        using (SKBitmap skBitmap = SKBitmap.Decode(skStream))
+        {
+            AddImageToBody(_document, mainPart.GetIdOfPart(imagePart), tag, ImagePartType.Png, skBitmap.Width, skBitmap.Height);
+        }
     }
     
     /// <summary>

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/DocxTemplateHelper.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/DocxTemplateHelper.cs
@@ -1,9 +1,11 @@
-﻿namespace Asv.Drones.Gui.Core;
+﻿using System.Text.RegularExpressions;
+
+namespace Asv.Drones.Gui.Core;
 
 internal static class DocxTemplateHelper
 {
     public static long Inches(this double size)
     {
-        return (long)(size * 1000000);
+        return (long)(size * 5000);
     }
 }

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/IDocxTemplate.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/Items/Templater/IDocxTemplate.cs
@@ -10,7 +10,7 @@ public interface IDocxTemplate : IDisposable
     /// <param name="imgFileName">path to image</param>
     /// <param name="width"></param>
     /// <param name="height"></param>
-    void Image(string tag, string path, double width, double height);
+    void Image(string tag, string path);
     /// <summary>
     /// Insert an image referenced either by a file path or a memory stream
     /// at a location marked by a tag in the document. 
@@ -19,7 +19,7 @@ public interface IDocxTemplate : IDisposable
     /// <param name="imageStream">image stream</param>
     /// <param name="width"></param>
     /// <param name="height"></param>
-    void Image(string tag, MemoryStream imageStream, double width, double height);
+    void Image(string tag, MemoryStream imageStream);
     /// <summary>
     /// This method is used to replace a specific tag
     /// with a provided text in headers, footers, and the document body.

--- a/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/ToolsMenuItem.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Header/TopMenu/Tools/ToolsMenuItem.cs
@@ -24,7 +24,7 @@ public class HeaderToolsMenu : HeaderMenuItem
             .Bind(out _items)
             .Subscribe()
             .DisposeItWith(Disposable);
-
+        
         Header = RS.HeaderToolsMenu_Header;
         Icon = MaterialIconKind.Tools;
         Order = short.MinValue;


### PR DESCRIPTION
Fixed a problem with the manual addition of image sizes in templates. The system now automatically calculates the sizes of the images injected into the `.docx` templates using the SkiaSharp library, rather than requiring manual input. This removes the possibility of errors due to incorrect dimensions. Also refactored Commands for adding tags in TemplaterViewModel for better clarity and performance. Minor GUI adjustments have been made for intuitive use. Finally, unnecessary white space and unused namespaces have been cleaned up.

Asana: https://app.asana.com/0/1203851531040615/1205412828145323/f