### PR TITLE
fix: update sorting logic in SdrPayloadBrowserViewModel

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Control/SdrPayloadBrowserViewModel.cs
@@ -117,9 +117,11 @@ public class SdrDeviceViewModel:ViewModelBase
         _loc = loc;
         _log = log;
         Client = device;
+        
         device.Sdr.Records
             .Transform(_=>new SdrPayloadRecordViewModel(device.Heartbeat.FullId, _, _log, _loc, device.Sdr))
-            .SortBy(_ => IsSortByName ? _.Name : _.CreatedDateTime)
+            .SortBy(_ => IsSortByName ? _.Name : _.CreatedDateTime, 
+                IsSortByName ? SortDirection.Ascending : SortDirection.Descending)
             .Bind(out _items)
             .DisposeMany()
             .Subscribe()
@@ -141,6 +143,13 @@ public class SdrDeviceViewModel:ViewModelBase
             .Subscribe(_ =>
             {
                 IsAnySelected = _ != null;
+            })
+            .DisposeItWith(Disposable);
+        
+        this.WhenAnyValue(_ => _.IsSortByName)
+            .Subscribe(_ =>
+            {
+                DownloadRecords.Execute().Subscribe();
             })
             .DisposeItWith(Disposable);
     }


### PR DESCRIPTION
Changes have been implemented in the SdrPayloadBrowserViewModel.cs to incorporate both ascending and descending sorting directions. This was spurred by the need to make sorting more dynamic, based on the value of IsSortByName. Additionally, an update has been introduced to trigger a download of records whenever a change is made to the 'IsSortByName' attribute.

Asana: https://app.asana.com/0/1203851531040615/1206007847454212/f