### PR TITLE
fix: simplify HierarchicalStoreEntryTagViewModel implementation

### DIFF
--- a/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreEntryTagViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreEntryTagViewModel.cs
@@ -6,22 +6,9 @@ using ReactiveUI;
 namespace Asv.Drones.Gui.Core;
 
 public class HierarchicalStoreEntryTagViewModel:ReactiveObject
-{
-    private const double CellWidth = 50;
-    private string _name;
+{ 
     public MaterialIconKind Icon { get; set; } = MaterialIconKind.Tag;
     public IBrush Color { get; set; }
-
-    public string Name
-    {
-        get => _name;
-        set
-        {
-            _name = value;
-            Width = (int)((_name.Length * 7 + 36) / CellWidth + 1) * CellWidth;
-        }
-    }
-    public double Width { get; private set; }
-    
+    public string Name { get; set; }
     public ICommand? Remove { get; set; }
 }

--- a/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreView.axaml
+++ b/src/Asv.Drones.Gui.Core/Controls/HierarchicalStore/HierarchicalStoreView.axaml
@@ -170,7 +170,7 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border Padding="2" Width="{Binding Width}">
+                                        <Border Padding="2">
                                             <Border HorizontalAlignment="Stretch" Background="{Binding Color}" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
                                                 <Grid ColumnDefinitions="18,*,18" Margin="3" HorizontalAlignment="Stretch" >
                                                     <avalonia:MaterialIcon  VerticalAlignment="Center" Foreground="White" Kind="TagOutline" Width="15" Height="15" />
@@ -179,7 +179,6 @@
                                                         <avalonia:MaterialIcon Kind="Close" Width="14" Height="14"/>
                                                     </Button>
                                                 </Grid>
-                                                
                                             </Border>    
                                         </Border>
                                     </DataTemplate>


### PR DESCRIPTION
Removed auto-calculated Width property from HierarchicalStoreEntryTagViewModel, which was contributing to unnecessary complexity. Instead, width in UI components is managed purely on the UI side. Also removed related Width bind in the HierarchicalStoreView.axaml, making design cleaner and more consistent.

Asana: https://app.asana.com/0/1203851531040615/1206076614321403/f