### PR TITLE
hotfix (sdr): fixed incorrect amplitude conversion in VorSdrRttViewModel

### DIFF
--- a/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Rtt/CustomControls/VorSdrRttViewModel.cs
+++ b/src/Asv.Drones.Gui.Sdr/Shell/Pages/Flight/Widgets/Sdr/Rtt/CustomControls/VorSdrRttViewModel.cs
@@ -166,8 +166,8 @@ public class VorSdrRttViewModel : ViewModelBase, ISdrRttWidget
                 PowerStringValue = _loc.Power.FromSiToString(_.Payload.Power);
                 FrequencyOffsetStringValue = _freqInKHzMeasureUnit?.FromSiToString(_.Payload.CarrierOffset);
                 BearingStringValue = _loc.Bearing.FromSiToString(_.Payload.Azimuth);
-                Am30HzStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.Am30 * 100.0);
-                Am9960HzStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.Am9960 * 100.0);
+                Am30HzStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.Am30);
+                Am9960HzStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.Am9960);
                 FmDeviationStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.Deviation * 100.0);
                 IdCodeStringValue = new string(_.Payload.CodeId.Select(__ => __ == '\0' ? ' ' : __).ToArray());
                 VoiceAmStringValue = _loc.AmplitudeModulation.FromSiToString(_.Payload.CodeIdAm1020 * 100.0);


### PR DESCRIPTION
The conversion for Am30HzStringValue and Am9960HzStringValue was previously multiplied by 100 unnecessarily. This caused the calculated amplitude modulation values to be incorrect. Ensure these values now reflect the actual payload amplitude by removing the unwanted multiplication.

Asana: https://app.asana.com/0/1203851531040615/1206178229986185/f