### PR TITLE
fix (core): add deselect behaviour for map anchors

### DIFF
--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageView.axaml
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageView.axaml
@@ -5,6 +5,8 @@
              xmlns:core="clr-namespace:Asv.Drones.Gui.Core"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:map="clr-namespace:Asv.Avalonia.Map;assembly=Asv.Drones.Gui.Map"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="core:MapPageViewModel"
              x:Class="Asv.Drones.Gui.Core.MapPageView">
@@ -12,8 +14,13 @@
 	<Design.DataContext>
         <core:MapPageViewModel/>
     </Design.DataContext>
-    <Grid d:ShowGridLines="True" ColumnDefinitions="*,5,3*,5,*" RowDefinitions="Auto,3*,5,*">
-        <map:MapView
+    <Grid d:ShowGridLines="True" ColumnDefinitions="*,5,3*,5,*" RowDefinitions="Auto,3*,5,*" Name="MainGrid">
+	    <i:Interaction.Behaviors>
+		    <ia:EventTriggerBehavior EventName="LostFocus" SourceObject="{Binding #MainGrid}">
+			    <ia:InvokeCommandAction Command="{CompiledBinding DeselectAnchorsCommand}" />
+		    </ia:EventTriggerBehavior>
+	    </i:Interaction.Behaviors>
+	    <map:MapView
 			MapProvider="{CompiledBinding MapProvider}"
 			SelectedItem="{Binding SelectedItem}"
 			Position="{CompiledBinding Center, Mode=TwoWay}"

--- a/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
+++ b/src/Asv.Drones.Gui.Core/Shell/Pages/Map/MapPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive.Linq;
+using System.Windows.Input;
 using Asv.Avalonia.Map;
 using Asv.Common;
 using DynamicData;
@@ -154,6 +155,17 @@ namespace Asv.Drones.Gui.Core
                     menuItem.Items = null;
                 _disposableMapUpdate?.Dispose();
             });
+
+            DeselectAnchorsCommand = ReactiveCommand.Create(() =>
+            {
+                SelectedItem = null;
+
+                foreach (var mapAnchor in Markers)
+                {
+                    if (mapAnchor.IsSelected)
+                        mapAnchor.IsSelected = false;
+                }
+            });
         }
 
         private void SetUpFollow(IMapAnchor anchor)
@@ -168,8 +180,8 @@ namespace Asv.Drones.Gui.Core
         public ReadOnlyObservableCollection<IMapWidget> LeftWidgets => _leftWidgets;
         public ReadOnlyObservableCollection<IMapWidget> RightWidgets => _rightWidgets;
         public ReadOnlyObservableCollection<IMapWidget> BottomWidgets => _bottomWidgets;
-
         public ReadOnlyObservableCollection<IMapAction> MapActions => _mapActions;
+        public ICommand DeselectAnchorsCommand { get; set; }
         
         #region Map properties
 


### PR DESCRIPTION
Add LostFocus behaviour for MapPageView.axaml, that invokes DeselectAnchorsCommand on it's viewmodel. This command disables SelectedItem on it's vm and checks for any selected anchors in Markers collection and sets IsSelected to false if there are any.

Asana: https://app.asana.com/0/1203851531040615/1206462230113635/f