### PR TITLE
fix(asv-drones): fix redundant object of type MainWindow creation and remove config delay

### DIFF
--- a/src/Asv.Drones.Gui.Core/CorePlugin.cs
+++ b/src/Asv.Drones.Gui.Core/CorePlugin.cs
@@ -22,7 +22,7 @@ public class CorePlugin: IPluginEntryPoint
         _applicationDataTemplateHost = applicationDataTemplateHost;
         var batch = new CompositionBatch();
         var path = GetAppPathInfo();
-        var config = new JsonOneFileConfiguration(path.ConfigFilePath, true, TimeSpan.FromSeconds(1));
+        var config = new JsonOneFileConfiguration(path.ConfigFilePath, true, null);
         batch.AddExportedValue(path);
         batch.AddExportedValue<IConfiguration>(config);
         batch.AddExportedValue(_defaultViewLocator = new ViewLocator(container));

--- a/src/Asv.Drones.Gui/App.axaml.cs
+++ b/src/Asv.Drones.Gui/App.axaml.cs
@@ -164,14 +164,13 @@ public partial class App : Application
             desktop.ShutdownRequested += OnShutdownRequested;
             var configuration = _container.GetExportedValue<IConfiguration>();
             Debug.Assert(configuration != null, nameof(configuration) + " != null");
-            var window = new MainWindow(configuration);
-            var navigation = _container.GetExportedValue<INavigationService>();
-            navigation?.InitStorageProvider(window.StorageProvider);
-            
-            desktop.MainWindow = new MainWindow
+            var window = new MainWindow(configuration)
             {
                 DataContext = _container.GetExportedValue<IShell>()
             };
+            var navigation = _container.GetExportedValue<INavigationService>();
+            navigation?.InitStorageProvider(window.StorageProvider);
+            desktop.MainWindow = window;
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
         {


### PR DESCRIPTION
Redundant creation of MainWindow object in App.xaml.cs is fixed for code optimization needs. Also found a bug with config save delay in CorePlugin. The delay was removed to immediately config refresh