### PR TITLE
fix(uav): refactor MissionStatusView layout

### DIFF
--- a/src/Asv.Drones.Gui/Shell/Pages/Flight/Widgets/Uav/FlightUavView.axaml
+++ b/src/Asv.Drones.Gui/Shell/Pages/Flight/Widgets/Uav/FlightUavView.axaml
@@ -80,6 +80,26 @@
                     <gui:MissionStatusView DataContext="{Binding MissionStatus}" />
                 </Viewbox>
             </StackPanel>
+            <Grid DockPanel.Dock="Bottom" DataContext="{Binding MissionStatus}">
+                <UniformGrid Columns="4" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Rows="1">
+                    <Button ToolTip.Tip="{x:Static gui:RS.MissionStatusView_GetMissionButton_ToolTip}" HorizontalAlignment="Stretch" Margin="1.5 0" Height="25"
+                            Command="{Binding Download}">
+                        <avalonia:MaterialIcon Kind="Sync" />
+                    </Button>
+                    <Button ToolTip.Tip="{x:Static gui:RS.MissionStatusView_DisableLayersButton_ToolTip}" HorizontalAlignment="Stretch" Margin="1.5 0" Height="25"
+                            Command="{Binding DisableAll}">
+                        <avalonia:MaterialIcon Kind="LayersClear" />
+                    </Button>
+                    <ToggleButton ToolTip.Tip="{x:Static gui:RS.MissionStatusView_TogglePolygonButton_ToolTip}" HorizontalAlignment="Stretch" Margin="1.5 0" Height="25"
+                                  IsChecked="{CompiledBinding EnablePolygon}">
+                        <avalonia:MaterialIcon Kind="VectorPolygon" />
+                    </ToggleButton>
+                    <ToggleButton ToolTip.Tip="{x:Static gui:RS.MissionStatusView_ToggleWaypointsButton_ToolTip}" HorizontalAlignment="Stretch" Margin="1.5 0" Height="25"
+                                  IsChecked="{CompiledBinding EnableAnchors}">
+                        <avalonia:MaterialIcon Kind="Anchor" />
+                    </ToggleButton>
+                </UniformGrid>
+            </Grid>
             <ItemsControl ItemsSource="{Binding RttItems}" IsVisible="{CompiledBinding !IsMinimized}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/Asv.Drones.Gui/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusView.axaml
+++ b/src/Asv.Drones.Gui/Shell/Pages/Flight/Widgets/Uav/MissionStatus/MissionStatusView.axaml
@@ -5,38 +5,20 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:gui="clr-namespace:Asv.Drones.Gui"
              xmlns:indicators="clr-namespace:Asv.Avalonia.Toolkit.UI.Controls.Indicators;assembly=Asv.Avalonia.Toolkit"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="175"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150"
              x:Class="Asv.Drones.Gui.MissionStatusView"
              x:CompileBindings="True"
              x:DataType="gui:MissionStatusViewModel">
     <Design.DataContext>
         <gui:MissionStatusViewModel />
     </Design.DataContext>
-    <DockPanel LastChildFill="True">
-        <Grid DockPanel.Dock="Top">
-            <WrapPanel HorizontalAlignment="Left">
-                <Button ToolTip.Tip="{x:Static gui:RS.MissionStatusView_GetMissionButton_ToolTip}"
-                        Command="{Binding Download}">
-                    <avalonia:MaterialIcon Kind="Sync" />
-                </Button>
-                <Button ToolTip.Tip="{x:Static gui:RS.MissionStatusView_DisableLayersButton_ToolTip}"
-                        Command="{Binding DisableAll}">
-                    <avalonia:MaterialIcon Kind="LayersClear" />
-                </Button>
-                <ToggleButton ToolTip.Tip="{x:Static gui:RS.MissionStatusView_TogglePolygonButton_ToolTip}"
-                              IsChecked="{CompiledBinding EnablePolygon}">
-                    <avalonia:MaterialIcon Kind="VectorPolygon" />
-                </ToggleButton>
-                <ToggleButton ToolTip.Tip="{x:Static gui:RS.MissionStatusView_ToggleWaypointsButton_ToolTip}"
-                              IsChecked="{CompiledBinding EnableAnchors}">
-                    <avalonia:MaterialIcon Kind="Anchor" />
-                </ToggleButton>
-            </WrapPanel>
-        </Grid>
-        <StackPanel Margin="0 5 0 10">
-        <indicators:RouteIndicator Progress="{Binding PathProgress}" StatusText="{Binding MissionFlightTime}"  Title="{x:Static gui:RS.MissionStatusView_MissionProgress_ToolTip}" SubStatusText="before complete"/>
-        <!-- <ProgressBar Value="{CompiledBinding Progress}" ShowProgressText="True"/> -->
-        <!-- <uav:MissionStatusIndicator WayPoints="{CompiledBinding WayPoints, Mode=TwoWay}" CurrentDistance="{CompiledBinding Distance}"/> -->
+    <DockPanel>
+        <StackPanel Margin="5 5 5 0" DockPanel.Dock="Top">
+            <indicators:RouteIndicator Progress="{Binding PathProgress}" StatusText="{Binding MissionFlightTime}"
+                                       Title="{x:Static gui:RS.MissionStatusView_MissionProgress_ToolTip}"
+                                       SubStatusText="before complete" />
+            <!-- <ProgressBar Value="{CompiledBinding Progress}" ShowProgressText="True"/> -->
+            <!-- <uav:MissionStatusIndicator WayPoints="{CompiledBinding WayPoints, Mode=TwoWay}" CurrentDistance="{CompiledBinding Distance}"/> -->
         </StackPanel>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
fix(uav): refactor MissionStatusView layout

- Reorganized the `MissionStatusView` layout to use `UniformGrid` for buttons.
- Moved mission status controls to `DockPanel.Bottom` within `FlightUavView`.

asana: https://app.asana.com/0/1203851531040615/1207643986818660/f
https://app.asana.com/0/1203851531040615/1207654116236034/f