### PR TITLE
Fix size optimization and ArgumentNullException in AnchorEditor widget

### DIFF
--- a/src/Asv.Drones.Gui.Api/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Api/RS.Designer.cs
@@ -87,6 +87,15 @@ namespace Asv.Drones.Gui.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Actions.
+        /// </summary>
+        public static string AnchorsEditorView_TextBlock_Actions {
+            get {
+                return ResourceManager.GetString("AnchorsEditorView_TextBlock_Actions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Altitude.
         /// </summary>
         public static string AnchorsEditorView_TextBlock_Altitude_Text {

--- a/src/Asv.Drones.Gui.Api/RS.resx
+++ b/src/Asv.Drones.Gui.Api/RS.resx
@@ -190,4 +190,7 @@
   <data name="Anchor_Editor_Action_Paste" xml:space="preserve">
     <value>Paste</value>
   </data>
+  <data name="AnchorsEditorView_TextBlock_Actions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Api/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Api/RS.ru.resx
@@ -186,4 +186,7 @@
   <data name="Anchor_Editor_Action_Paste" xml:space="preserve">
     <value>Вставить</value>
   </data>
+  <data name="AnchorsEditorView_TextBlock_Actions" xml:space="preserve">
+    <value>Действия</value>
+  </data>
 </root>

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -91,7 +91,8 @@
                     </Grid>
                 </StackPanel>
             </ScrollViewer>
-            <TextBlock Grid.Row="0" 
+            <TextBlock x:Name="ActionsTextBlock" 
+                       Grid.Row="0"
                        Grid.Column="2" 
                        Margin="5"
                        IsVisible="{CompiledBinding !!Actions}"
@@ -99,7 +100,7 @@
             <Rectangle Grid.Row="0"
                     Grid.Column="1"
                     Grid.RowSpan="2"
-                    Fill="White">
+                    Fill="{Binding Foreground, ElementName=ActionsTextBlock}">
                 <Rectangle.IsVisible>
                     <MultiBinding Converter="{x:Static BoolConverters.And}">
                         <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:api="clr-namespace:Asv.Drones.Gui.Api"
-             xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
              xmlns:buttons="clr-namespace:Asv.Avalonia.Toolkit.UI.Controls.Buttons;assembly=Asv.Avalonia.Toolkit"
              mc:Ignorable="d"
              d:DesignWidth="900"

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -5,8 +5,9 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:api="clr-namespace:Asv.Drones.Gui.Api"
              xmlns:buttons="clr-namespace:Asv.Avalonia.Toolkit.UI.Controls.Buttons;assembly=Asv.Avalonia.Toolkit"
+             xmlns:map="clr-namespace:Asv.Avalonia.Map;assembly=Asv.Avalonia.Map"
              mc:Ignorable="d"
-             d:DesignWidth="900"
+             d:DesignWidth="700"
              d:DesignHeight="300"
              x:Class="Asv.Drones.Gui.Api.AnchorsEditorView"
              x:DataType="api:AnchorsEditorViewModel"
@@ -14,183 +15,151 @@
     <Design.DataContext>
         <api:AnchorsEditorViewModel />
     </Design.DataContext>
-    <UserControl.Styles>
-        <Style Selector="Button.MenuButton">
-            <Setter Property="Template">
-                <ControlTemplate>
-                    <ContentPresenter Content="{TemplateBinding Content}"/>      
-                </ControlTemplate>
-            </Setter>
-        </Style>
-        <Style Selector="Expander">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Padding" Value="0 0 0 0" />
-        </Style>
-        <Style Selector="Expander /template/ ToggleButton#PART_toggle">
-            <Setter Property="Padding" Value="0 0 0 0" />
-            <Setter Property="BorderThickness" Value="0" />
-        </Style>
-        <Style Selector="Border#ExpandCollapseChevronBorder">
-            <Setter Property="MinHeight" Value="120" />
-            <Setter Property="MaxWidth" Value="20" />
-        </Style>
-    </UserControl.Styles>
-    <Grid ColumnDefinitions="Auto,*" x:Name="PART_Grid"
-          EffectiveViewportChanged="Layoutable_OnEffectiveViewportChanged">
-        <ScrollViewer Grid.Column="0">
-            <StackPanel Margin="10,10,15,0" Spacing="8" Grid.IsSharedSizeScope="True">
-                <StackPanel Margin="0 0 0 10" Orientation="Horizontal" Spacing="8">
-                    <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
-                    <TextBlock Text="{CompiledBinding Map.SelectedItem.Title}" />
+    <Border ClipToBounds="True" Padding="10">
+        <Grid ColumnDefinitions="Auto,10,*" RowDefinitions="20,*" x:Name="PART_Grid"
+              EffectiveViewportChanged="Layoutable_OnEffectiveViewportChanged">
+            <StackPanel Grid.Column="0" Grid.Row="0" Margin="10,10,15,0" Orientation="Horizontal" Spacing="8">
+                <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
+                <TextBlock Text="{CompiledBinding Map.SelectedItem.Title}" />
+            </StackPanel>
+            <ScrollViewer Grid.Row="1" Grid.Column="0">
+                <StackPanel Margin="10,10,15,0" Spacing="8" Grid.IsSharedSizeScope="True">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition SharedSizeGroup="Name" />
+                            <ColumnDefinition SharedSizeGroup="Space" Width="15" />
+                            <ColumnDefinition SharedSizeGroup="Value" Width="250" />
+                            <ColumnDefinition SharedSizeGroup="Action" Width="45" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" 
+                                   VerticalAlignment="Center" 
+                                   Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}"/>
+                        <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                            <Interaction.Behaviors>
+                                <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Latitude}" />
+                            </Interaction.Behaviors>
+                            <TextBox.InnerRightContent>
+                                <TextBlock Text="{CompiledBinding LatitudeUnits}" VerticalAlignment="Center"
+                                           Margin="8 4" />
+                            </TextBox.InnerRightContent>
+                        </TextBox>
+                        <Button Margin="5 0 0 0" Height="32" Grid.Column="3" VerticalAlignment="Top"
+                                Command="{CompiledBinding CopyCommand}">
+                            <avalonia:MaterialIcon Kind="ContentCopy" />
+                        </Button>
+                    </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition SharedSizeGroup="Name" />
+                            <ColumnDefinition SharedSizeGroup="Space" />
+                            <ColumnDefinition SharedSizeGroup="Value" />
+                            <ColumnDefinition SharedSizeGroup="Action" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Longitude_Text}"
+                                   Grid.Column="0" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                            <Interaction.Behaviors>
+                                <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Longitude}" />
+                            </Interaction.Behaviors>
+                            <TextBox.InnerRightContent>
+                                <TextBlock Text="{Binding LongitudeUnits }" VerticalAlignment="Center" Margin="8 4" />
+                            </TextBox.InnerRightContent>
+                        </TextBox>
+                        <Button Grid.Column="3" Margin="5 0 0 0 " Height="32" Command="{CompiledBinding PasteCommand}"
+                                IsVisible="{CompiledBinding IsEditable}">
+                            <avalonia:MaterialIcon Kind="ContentPaste" />
+                        </Button>
+                    </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition SharedSizeGroup="Name" />
+                            <ColumnDefinition SharedSizeGroup="Space" />
+                            <ColumnDefinition SharedSizeGroup="Value" />
+                            <ColumnDefinition SharedSizeGroup="Action" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Altitude_Text}"
+                                   Grid.Column="0" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                            <Interaction.Behaviors>
+                                <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Altitude}" />
+                            </Interaction.Behaviors>
+                            <TextBox.InnerRightContent>
+                                <TextBlock Text="{CompiledBinding AltitudeUnits}" VerticalAlignment="Center"
+                                           Margin="8 4" />
+                            </TextBox.InnerRightContent>
+                        </TextBox>
+                    </Grid>
                 </StackPanel>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="Name" />
-                        <ColumnDefinition SharedSizeGroup="Space" Width="15" />
-                        <ColumnDefinition SharedSizeGroup="Value" Width="250" />
-                        <ColumnDefinition SharedSizeGroup="Action" Width="45" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}"
-                               Grid.Column="0" VerticalAlignment="Center" />
-                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                        <Interaction.Behaviors>
-                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Latitude}" />
-                        </Interaction.Behaviors>
-                        <TextBox.InnerRightContent>
-                            <TextBlock Text="{CompiledBinding LatitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
-                        </TextBox.InnerRightContent>
-                    </TextBox>
-                    <Button Margin="5 0 0 0" Height="32" Grid.Column="3" VerticalAlignment="Top"
-                            Command="{CompiledBinding CopyCommand}">
-                        <avalonia:MaterialIcon Kind="ContentCopy" />
-                    </Button>
-                </Grid>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="Name" />
-                        <ColumnDefinition SharedSizeGroup="Space" />
-                        <ColumnDefinition SharedSizeGroup="Value" />
-                        <ColumnDefinition SharedSizeGroup="Action" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Longitude_Text}"
-                               Grid.Column="0" VerticalAlignment="Center" />
-                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                        <Interaction.Behaviors>
-                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Longitude}" />
-                        </Interaction.Behaviors>
-                        <TextBox.InnerRightContent>
-                            <TextBlock Text="{Binding LongitudeUnits }" VerticalAlignment="Center" Margin="8 4" />
-                        </TextBox.InnerRightContent>
-                    </TextBox>
-                    <Button Grid.Column="3" Margin="5 0 0 0 " Height="32" Command="{CompiledBinding PasteCommand}"
-                            IsVisible="{CompiledBinding IsEditable}">
-                        <avalonia:MaterialIcon Kind="ContentPaste" />
-                    </Button>
-                </Grid>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="Name" />
-                        <ColumnDefinition SharedSizeGroup="Space" />
-                        <ColumnDefinition SharedSizeGroup="Value" />
-                        <ColumnDefinition SharedSizeGroup="Action" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Altitude_Text}"
-                               Grid.Column="0" VerticalAlignment="Center" />
-                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                        <Interaction.Behaviors>
-                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Altitude}" />
-                        </Interaction.Behaviors>
-                        <TextBox.InnerRightContent>
-                            <TextBlock Text="{CompiledBinding AltitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
-                        </TextBox.InnerRightContent>
-                    </TextBox>
-                </Grid>
-            </StackPanel>
-        </ScrollViewer>
-        <ScrollViewer Grid.Column="1" IsVisible="{CompiledBinding !!Actions}">
-            <StackPanel x:Name="PART_ActionsPanel"
-                        VerticalAlignment="Top"
-                        HorizontalAlignment="Left">
-                <TextBlock Text="Actions" Margin="5" />
-                <Border IsVisible="{Binding !IsCompactMode}" BorderBrush="White"
-                        Margin="0,10,0,0"
-                        MaxHeight="200"
-                        BorderThickness="2,0,0,0">
-                    <ScrollViewer>
-                        <Grid ColumnDefinitions="*">
-                            <Expander ExpandDirection="Right"
-                                      IsExpanded="True">
-                                <Expander.Resources>
-                                    <Border x:Key="ExpanderChevronMargin" Margin="0 0 0 0" />
-                                    <SolidColorBrush x:Key="ExpanderChevronBorderBrush" Color="Transparent" />
-                                    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
-                                    <Thickness x:Key="ExpanderChevronBorderThickness">0,0,0,0</Thickness>
-                                    <Thickness x:Key="ExpanderContentRightBorderThickness">0,0,0,0</Thickness>
-                                </Expander.Resources>
-                                <ItemsControl ItemsSource="{CompiledBinding Actions}">
-                                    <ItemsControl.IsVisible>
-                                        <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                            <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
-                                            <Binding Path="!IsCompactMode" />
-                                        </MultiBinding>
-                                    </ItemsControl.IsVisible>
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Stretch" />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <buttons:StepSizingButton Classes="MenuButton" StepSizeWidth="100"
-                                                                      HorizontalAlignment="Stretch" Margin="2"
-                                                                      Command="{CompiledBinding Command}">
-                                                <Grid ColumnDefinitions="Auto, 5, *">
-                                                    <avalonia:MaterialIcon Grid.Column="0"
-                                                                           Kind="{CompiledBinding Icon}" />
-                                                    <TextBlock Grid.Column="2" HorizontalAlignment="Center"
-                                                               Text="{CompiledBinding Title}"
-                                                               TextTrimming="CharacterEllipsis" />
-                                                </Grid>
-                                            </buttons:StepSizingButton>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </Expander>
-                        </Grid>
-                    </ScrollViewer>
-                </Border>
-                <DropDownButton Theme="{DynamicResource TransparentButton}" Margin="10">
-                    <avalonia:MaterialIcon Width="18" Height="18" Kind="DotsVertical" />
-                    <DropDownButton.IsVisible>
-                        <MultiBinding Converter="{x:Static BoolConverters.And}">
-                            <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
-                            <Binding Path="IsCompactMode" />
-                        </MultiBinding>
-                    </DropDownButton.IsVisible>
-                    <DropDownButton.Flyout>
-                        <MenuFlyout>
-                            <ItemsControl ItemsSource="{CompiledBinding Actions}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <StackPanel Spacing="5"></StackPanel>
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Button Classes="MenuButton" HorizontalAlignment="Stretch"
-                                                Command="{CompiledBinding Command}">
-                                            <StackPanel Orientation="Horizontal" Spacing="3">
-                                                <avalonia:MaterialIcon Kind="{CompiledBinding Icon}" />
-                                                <TextBlock Text="{CompiledBinding Title}" />
-                                            </StackPanel>
-                                        </Button>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </MenuFlyout>
-                    </DropDownButton.Flyout>
-                </DropDownButton>
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+            </ScrollViewer>
+            <TextBlock Grid.Row="0" Grid.Column="2" Text="Actions" Margin="5" />
+            <Border Grid.Row="0"
+                    Grid.Column="1" 
+                    Grid.RowSpan="2" 
+                    Height="150"
+                    BorderBrush="White"
+                    VerticalAlignment="Top"
+                    Margin="0,10,0,0"
+                    BorderThickness="2,0,0,0"
+                    IsVisible="{Binding !IsCompactMode}"/>
+            <ScrollViewer Grid.Row="1" Grid.Column="2" IsVisible="{CompiledBinding !!Actions}">
+                <StackPanel x:Name="PART_ActionsPanel"
+                            VerticalAlignment="Top"
+                            HorizontalAlignment="Left">
+                    <Grid ColumnDefinitions="*">
+                        <ItemsControl ItemsSource="{CompiledBinding Actions}">
+                            <ItemsControl.IsVisible>
+                                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                    <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
+                                    <Binding Path="!IsCompactMode" />
+                                </MultiBinding>
+                            </ItemsControl.IsVisible>
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Margin="5" Orientation="Horizontal"
+                                               HorizontalAlignment="Stretch" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <buttons:StepSizingButton StepSizeWidth="100"
+                                                              HorizontalAlignment="Stretch" Margin="2"
+                                                              Command="{CompiledBinding Command}">
+                                        <Grid ColumnDefinitions="Auto, 5, *">
+                                            <avalonia:MaterialIcon Grid.Column="0"
+                                                                   Kind="{CompiledBinding Icon}" />
+                                            <TextBlock Grid.Column="2" HorizontalAlignment="Center"
+                                                       Text="{CompiledBinding Title}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                        </Grid>
+                                    </buttons:StepSizingButton>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Grid>
+                    <DropDownButton Theme="{DynamicResource TransparentButton}" Margin="10">
+                        <avalonia:MaterialIcon Width="18" Height="18" Kind="DotsVertical" />
+                        <DropDownButton.IsVisible>
+                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
+                                <Binding Path="IsCompactMode" />
+                            </MultiBinding>
+                        </DropDownButton.IsVisible>
+                        <DropDownButton.Flyout>
+                            <MenuFlyout Placement="Bottom" ItemsSource="{CompiledBinding Actions}">
+                                <MenuFlyout.ItemContainerTheme>
+                                    <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}"
+                                                  x:DataType="map:MapAnchorActionViewModel">
+                                        <Setter Property="Header" Value="{CompiledBinding Title}" />
+                                        <Setter Property="Icon"
+                                                Value="{CompiledBinding Icon, Converter={x:Static api:MaterialIconConverter.Instance}}" />
+                                        <Setter Property="Command" Value="{CompiledBinding Command}" />
+                                    </ControlTheme>
+                                </MenuFlyout.ItemContainerTheme>
+                            </MenuFlyout>
+                        </DropDownButton.Flyout>
+                    </DropDownButton>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Border>
 </UserControl>

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -16,7 +16,7 @@
         <api:AnchorsEditorViewModel />
     </Design.DataContext>
     <Border ClipToBounds="True" Padding="10">
-        <Grid ColumnDefinitions="Auto,10,*" RowDefinitions="20,*" x:Name="PART_Grid"
+        <Grid ColumnDefinitions="Auto,2,*" RowDefinitions="20,*" x:Name="PART_Grid"
               EffectiveViewportChanged="Layoutable_OnEffectiveViewportChanged">
             <StackPanel Grid.Column="0" Grid.Row="0" Margin="10,10,15,0" Orientation="Horizontal" Spacing="8">
                 <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
@@ -31,9 +31,9 @@
                             <ColumnDefinition SharedSizeGroup="Value" Width="250" />
                             <ColumnDefinition SharedSizeGroup="Action" Width="45" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" 
-                                   VerticalAlignment="Center" 
-                                   Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}"/>
+                        <TextBlock Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}" />
                         <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
                             <Interaction.Behaviors>
                                 <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Latitude}" />
@@ -92,15 +92,11 @@
                 </StackPanel>
             </ScrollViewer>
             <TextBlock Grid.Row="0" Grid.Column="2" Text="Actions" Margin="5" />
-            <Border Grid.Row="0"
-                    Grid.Column="1" 
-                    Grid.RowSpan="2" 
-                    Height="150"
-                    BorderBrush="White"
-                    VerticalAlignment="Top"
-                    Margin="0,10,0,0"
-                    BorderThickness="2,0,0,0"
-                    IsVisible="{Binding !IsCompactMode}"/>
+            <Rectangle Grid.Row="0"
+                    Grid.Column="1"
+                    Grid.RowSpan="2"
+                    Fill="White"
+                    IsVisible="{Binding !IsCompactMode}" />
             <ScrollViewer Grid.Row="1" Grid.Column="2" IsVisible="{CompiledBinding !!Actions}">
                 <StackPanel x:Name="PART_ActionsPanel"
                             VerticalAlignment="Top"

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -16,7 +16,7 @@
         <api:AnchorsEditorViewModel />
     </Design.DataContext>
     <Border ClipToBounds="True" Padding="10">
-        <Grid ColumnDefinitions="Auto,2,*" RowDefinitions="20,*" x:Name="PART_Grid"
+        <Grid ColumnDefinitions="Auto,2,*" RowDefinitions="Auto,*" x:Name="PART_Grid"
               EffectiveViewportChanged="Layoutable_OnEffectiveViewportChanged">
             <StackPanel Grid.Column="0" Grid.Row="0" Margin="10,10,15,0" Orientation="Horizontal" Spacing="8">
                 <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
@@ -91,12 +91,22 @@
                     </Grid>
                 </StackPanel>
             </ScrollViewer>
-            <TextBlock Grid.Row="0" Grid.Column="2" Text="Actions" Margin="5" />
+            <TextBlock Grid.Row="0" 
+                       Grid.Column="2" 
+                       Margin="5"
+                       IsVisible="{CompiledBinding !!Actions}"
+                       Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Actions}" />
             <Rectangle Grid.Row="0"
                     Grid.Column="1"
                     Grid.RowSpan="2"
-                    Fill="White"
-                    IsVisible="{Binding !IsCompactMode}" />
+                    Fill="White">
+                <Rectangle.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
+                        <Binding Path="!IsCompactMode" />
+                    </MultiBinding>
+                </Rectangle.IsVisible>
+            </Rectangle>
             <ScrollViewer Grid.Row="1" Grid.Column="2" IsVisible="{CompiledBinding !!Actions}">
                 <StackPanel x:Name="PART_ActionsPanel"
                             VerticalAlignment="Top"

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorView.axaml
@@ -37,82 +37,83 @@
     </UserControl.Styles>
     <Grid ColumnDefinitions="Auto,*" x:Name="PART_Grid"
           EffectiveViewportChanged="Layoutable_OnEffectiveViewportChanged">
-        <StackPanel Grid.Column="0" Margin="10,10,5,0" Spacing="8" Grid.IsSharedSizeScope="True">
-            <StackPanel Margin="0 0 0 10" Orientation="Horizontal" Spacing="8">
-                <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
-                <TextBlock Text="{CompiledBinding Map.SelectedItem.Title}" />
+        <ScrollViewer Grid.Column="0">
+            <StackPanel Margin="10,10,15,0" Spacing="8" Grid.IsSharedSizeScope="True">
+                <StackPanel Margin="0 0 0 10" Orientation="Horizontal" Spacing="8">
+                    <avalonia:MaterialIcon Kind="{CompiledBinding Map.SelectedItem.Icon}" />
+                    <TextBlock Text="{CompiledBinding Map.SelectedItem.Title}" />
+                </StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="Name" />
+                        <ColumnDefinition SharedSizeGroup="Space" Width="15" />
+                        <ColumnDefinition SharedSizeGroup="Value" Width="250" />
+                        <ColumnDefinition SharedSizeGroup="Action" Width="45" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}"
+                               Grid.Column="0" VerticalAlignment="Center" />
+                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                        <Interaction.Behaviors>
+                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Latitude}" />
+                        </Interaction.Behaviors>
+                        <TextBox.InnerRightContent>
+                            <TextBlock Text="{CompiledBinding LatitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                    <Button Margin="5 0 0 0" Height="32" Grid.Column="3" VerticalAlignment="Top"
+                            Command="{CompiledBinding CopyCommand}">
+                        <avalonia:MaterialIcon Kind="ContentCopy" />
+                    </Button>
+                </Grid>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="Name" />
+                        <ColumnDefinition SharedSizeGroup="Space" />
+                        <ColumnDefinition SharedSizeGroup="Value" />
+                        <ColumnDefinition SharedSizeGroup="Action" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Longitude_Text}"
+                               Grid.Column="0" VerticalAlignment="Center" />
+                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                        <Interaction.Behaviors>
+                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Longitude}" />
+                        </Interaction.Behaviors>
+                        <TextBox.InnerRightContent>
+                            <TextBlock Text="{Binding LongitudeUnits }" VerticalAlignment="Center" Margin="8 4" />
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                    <Button Grid.Column="3" Margin="5 0 0 0 " Height="32" Command="{CompiledBinding PasteCommand}"
+                            IsVisible="{CompiledBinding IsEditable}">
+                        <avalonia:MaterialIcon Kind="ContentPaste" />
+                    </Button>
+                </Grid>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="Name" />
+                        <ColumnDefinition SharedSizeGroup="Space" />
+                        <ColumnDefinition SharedSizeGroup="Value" />
+                        <ColumnDefinition SharedSizeGroup="Action" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Altitude_Text}"
+                               Grid.Column="0" VerticalAlignment="Center" />
+                    <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
+                        <Interaction.Behaviors>
+                            <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Altitude}" />
+                        </Interaction.Behaviors>
+                        <TextBox.InnerRightContent>
+                            <TextBlock Text="{CompiledBinding AltitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                </Grid>
             </StackPanel>
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition SharedSizeGroup="Name" />
-                    <ColumnDefinition SharedSizeGroup="Space" Width="15" />
-                    <ColumnDefinition SharedSizeGroup="Value" Width="250" />
-                    <ColumnDefinition SharedSizeGroup="Action" Width="45" />
-
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Latitude_Text}"
-                           Grid.Column="0" VerticalAlignment="Center" />
-                <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                    <Interaction.Behaviors>
-                        <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Latitude}" />
-                    </Interaction.Behaviors>
-                    <TextBox.InnerRightContent>
-                        <TextBlock Text="{CompiledBinding LatitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
-                    </TextBox.InnerRightContent>
-                </TextBox>
-                <Button Margin="5 0 0 0" Height="32" Grid.Column="3" VerticalAlignment="Top"
-                        Command="{CompiledBinding CopyCommand}">
-                    <avalonia:MaterialIcon Kind="ContentCopy" />
-                </Button>
-            </Grid>
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition SharedSizeGroup="Name" />
-                    <ColumnDefinition SharedSizeGroup="Space" />
-                    <ColumnDefinition SharedSizeGroup="Value" />
-                    <ColumnDefinition SharedSizeGroup="Action" />
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Longitude_Text}"
-                           Grid.Column="0" VerticalAlignment="Center" />
-                <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                    <Interaction.Behaviors>
-                        <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Longitude}" />
-                    </Interaction.Behaviors>
-                    <TextBox.InnerRightContent>
-                        <TextBlock Text="{Binding LongitudeUnits }" VerticalAlignment="Center" Margin="8 4" />
-                    </TextBox.InnerRightContent>
-                </TextBox>
-                <Button Grid.Column="3" Margin="5 0 0 0 " Height="32" Command="{CompiledBinding PasteCommand}"
-                        IsVisible="{CompiledBinding IsEditable}">
-                    <avalonia:MaterialIcon Kind="ContentPaste" />
-                </Button>
-            </Grid>
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition SharedSizeGroup="Name" />
-                    <ColumnDefinition SharedSizeGroup="Space" />
-                    <ColumnDefinition SharedSizeGroup="Value" />
-                    <ColumnDefinition SharedSizeGroup="Action" />
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="{x:Static api:RS.AnchorsEditorView_TextBlock_Altitude_Text}"
-                           Grid.Column="0" VerticalAlignment="Center" />
-                <TextBox Grid.Column="2" IsReadOnly="{CompiledBinding !Map.SelectedItem.IsEditable}">
-                    <Interaction.Behaviors>
-                        <api:LostFocusUpdateBindingBehavior Text="{CompiledBinding Altitude}" />
-                    </Interaction.Behaviors>
-                    <TextBox.InnerRightContent>
-                        <TextBlock Text="{CompiledBinding AltitudeUnits}" VerticalAlignment="Center" Margin="8 4" />
-                    </TextBox.InnerRightContent>
-                </TextBox>
-            </Grid>
-            </StackPanel>
-            <StackPanel x:Name="PART_ActionsPanel" Grid.Column="1" IsVisible="{CompiledBinding !!Actions}"
+        </ScrollViewer>
+        <ScrollViewer Grid.Column="1" IsVisible="{CompiledBinding !!Actions}">
+            <StackPanel x:Name="PART_ActionsPanel"
                         VerticalAlignment="Top"
                         HorizontalAlignment="Left">
                 <TextBlock Text="Actions" Margin="5" />
                 <Border IsVisible="{Binding !IsCompactMode}" BorderBrush="White"
                         Margin="0,10,0,0"
-                       
                         MaxHeight="200"
                         BorderThickness="2,0,0,0">
                     <ScrollViewer>
@@ -140,11 +141,15 @@
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
-                                            <buttons:StepSizingButton Classes="MenuButton" StepSizeWidth="100"  HorizontalAlignment="Stretch" Margin="2" Command="{CompiledBinding Command}" >
+                                            <buttons:StepSizingButton Classes="MenuButton" StepSizeWidth="100"
+                                                                      HorizontalAlignment="Stretch" Margin="2"
+                                                                      Command="{CompiledBinding Command}">
                                                 <Grid ColumnDefinitions="Auto, 5, *">
-                                                    <avalonia:MaterialIcon Grid.Column="0" Kind="{CompiledBinding Icon}" />
-                                                    <TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="{CompiledBinding Title}"
-                                                               TextTrimming="CharacterEllipsis"  />
+                                                    <avalonia:MaterialIcon Grid.Column="0"
+                                                                           Kind="{CompiledBinding Icon}" />
+                                                    <TextBlock Grid.Column="2" HorizontalAlignment="Center"
+                                                               Text="{CompiledBinding Title}"
+                                                               TextTrimming="CharacterEllipsis" />
                                                 </Grid>
                                             </buttons:StepSizingButton>
                                         </DataTemplate>
@@ -154,8 +159,8 @@
                         </Grid>
                     </ScrollViewer>
                 </Border>
-                <DropDownButton  Theme="{DynamicResource TransparentButton}" Margin="10">
-                    <avalonia:MaterialIcon Width="18" Height="18" Kind="DotsVertical"/>
+                <DropDownButton Theme="{DynamicResource TransparentButton}" Margin="10">
+                    <avalonia:MaterialIcon Width="18" Height="18" Kind="DotsVertical" />
                     <DropDownButton.IsVisible>
                         <MultiBinding Converter="{x:Static BoolConverters.And}">
                             <Binding Path="Actions" Converter="{x:Static ObjectConverters.IsNotNull}" />
@@ -164,7 +169,7 @@
                     </DropDownButton.IsVisible>
                     <DropDownButton.Flyout>
                         <MenuFlyout>
-                            <ItemsControl  ItemsSource="{CompiledBinding Actions}">
+                            <ItemsControl ItemsSource="{CompiledBinding Actions}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Spacing="5"></StackPanel>
@@ -172,18 +177,20 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Button Classes="MenuButton" HorizontalAlignment="Stretch"  Command="{CompiledBinding Command}">
+                                        <Button Classes="MenuButton" HorizontalAlignment="Stretch"
+                                                Command="{CompiledBinding Command}">
                                             <StackPanel Orientation="Horizontal" Spacing="3">
-                                                <avalonia:MaterialIcon Kind="{CompiledBinding Icon}"/>
-                                                <TextBlock Text="{CompiledBinding Title}"/>     
+                                                <avalonia:MaterialIcon Kind="{CompiledBinding Icon}" />
+                                                <TextBlock Text="{CompiledBinding Title}" />
                                             </StackPanel>
                                         </Button>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
-                            </ItemsControl>    
+                            </ItemsControl>
                         </MenuFlyout>
                     </DropDownButton.Flyout>
                 </DropDownButton>
             </StackPanel>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
@@ -261,7 +261,7 @@ public class AnchorsEditorViewModel : MapWidgetBase
 
                 if (_ != null)
                 {
-                    Actions = _.Actions.OrderByDescending(_=>_.Title.Length);
+                    if (_.Actions is not null) Actions = _.Actions.OrderByDescending(_=>_.Title.Length);
                     _prevAnchor = _;
                     IsVisible = true;
                     IsEditable = _.IsEditable;

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
@@ -249,6 +249,7 @@ public class AnchorsEditorViewModel : MapWidgetBase
         context.WhenValueChanged(_ => _.SelectedItem)
             .Subscribe(_ =>
             {
+                Actions = null;
                 if (_prevAnchor != null && _prevAnchor.IsInEditMode)
                 {
                     UpdateLatitude(Latitude);

--- a/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
+++ b/src/Asv.Drones.Gui.Api/Tools/Controls/Map/Widgets/AnchorEditor/AnchorsEditorViewModel.cs
@@ -261,7 +261,7 @@ public class AnchorsEditorViewModel : MapWidgetBase
 
                 if (_ != null)
                 {
-                    Actions = _.Actions;
+                    Actions = _.Actions.OrderByDescending(_=>_.Title.Length);
                     _prevAnchor = _;
                     IsVisible = true;
                     IsEditable = _.IsEditable;

--- a/src/Asv.Drones.Gui/RS.Designer.cs
+++ b/src/Asv.Drones.Gui/RS.Designer.cs
@@ -4021,7 +4021,7 @@ namespace Asv.Drones.Gui {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reboot/Shutdown Autopilot.
+        ///   Looks up a localized string similar to Reboot/Shutdown.
         /// </summary>
         public static string RebootAutopilotAnchorActionViewModel_Title {
             get {

--- a/src/Asv.Drones.Gui/RS.resx
+++ b/src/Asv.Drones.Gui/RS.resx
@@ -1190,8 +1190,8 @@
     <data name="RebootAutopilotView_CompanionReboot_Description" xml:space="preserve">
     <value>Choose companion reboot/shutdown mode</value>
   </data>
-    <data name="RebootAutopilotAnchorActionViewModel_Title" xml:space="preserve">
-    <value>Reboot/Shutdown Autopilot</value>
+  <data name="RebootAutopilotAnchorActionViewModel_Title" xml:space="preserve">
+    <value>Reboot/Shutdown</value>
   </data>
     <data name="RebootAutopilotAnchorActionViewModel_DialogPrimaryButton" xml:space="preserve">
     <value>Ok</value>

--- a/src/Asv.Drones.Gui/RS.ru.resx
+++ b/src/Asv.Drones.Gui/RS.ru.resx
@@ -1231,8 +1231,8 @@
     <data name="RebootAutopilotAnchorActionViewModel_LogMessage" xml:space="preserve">
     <value>Пользователь отправил комманду перезагрузки автопилота с параметрами {0} и {1}</value>
   </data>
-    <data name="SelectModeAnchorActionViewModel_Title" xml:space="preserve">
-    <value>Выбор режима БПЛА</value>
+  <data name="SelectModeAnchorActionViewModel_Title" xml:space="preserve">
+    <value>Режимы БПЛА</value>
   </data>
     <data name="SelectModeAnchorActionViewModel_DialogPrimaryButton" xml:space="preserve">
     <value>Ок</value>
@@ -1393,8 +1393,8 @@
     <data name="VehiclesShellMenuItemProvider_ShellMenuItem_Settings" xml:space="preserve">
     <value>Настройки</value>
   </data>
-    <data name="LandAnchorActionViewModel_Title" xml:space="preserve">
-    <value>Немедленно приземлиться</value>
+  <data name="LandAnchorActionViewModel_Title" xml:space="preserve">
+    <value>Приземлиться</value>
   </data>
     <data name="GoToMapAnchorActionViewModel_Title" xml:space="preserve">
     <value>Перейти в точку</value>
@@ -1408,8 +1408,8 @@
     <data name="LandAnchorActionViewModel_ExecuteImpl_LogInfo" xml:space="preserve">
     <value>Пользователь отправил команду приземлиться для {0}</value>
   </data>
-    <data name="RtlAnchorActionViewModel_RTL" xml:space="preserve">
-    <value>Вернуться в точку запуска</value>
+  <data name="RtlAnchorActionViewModel_RTL" xml:space="preserve">
+    <value>Вернуться домой</value>
   </data>
     <data name="RtlAnchorActionViewModel_ExecuteImpl_LogInfo" xml:space="preserve">
     <value>Пользователь отправил команду вернуться в точку запуска для {0}</value>
@@ -1811,7 +1811,7 @@
     <value>мин</value>
   </data>
   <data name="FlightUavViewModel_RtlCommand_Name" xml:space="preserve">
-    <value>Вернуться в точку запуска</value>
+    <value>Вернуться домой</value>
   </data>
   <data name="FlightUavViewModel_StartMissionCommand_Name" xml:space="preserve">
     <value>Начать миссию</value>

--- a/src/Asv.Drones.Gui/RS.ru.resx
+++ b/src/Asv.Drones.Gui/RS.ru.resx
@@ -1219,8 +1219,8 @@
     <data name="RebootAutopilotView_CompanionReboot_Description" xml:space="preserve">
     <value>Выберите режим перезапуска/отключения бортового компьютера</value>
   </data>
-    <data name="RebootAutopilotAnchorActionViewModel_Title" xml:space="preserve">
-    <value>Перезагрузить/Выключить автопилот</value>
+  <data name="RebootAutopilotAnchorActionViewModel_Title" xml:space="preserve">
+    <value>Перезагрузить/Выключить</value>
   </data>
     <data name="RebootAutopilotAnchorActionViewModel_DialogPrimaryButton" xml:space="preserve">
     <value>Ок</value>


### PR DESCRIPTION
In this PR: 
fix ArgumentNullException with null check of actions collection of anchor;
size optimization with more short locales; 
more efficient markup that allows the control to be used in a compressed state

Asana:
https://app.asana.com/0/1203851531040615/1207664866852418/f
https://app.asana.com/0/1203851531040615/1207654116236041/f
https://app.asana.com/0/1203851531040615/1207643849991138/f