### PR TITLE
fix (market): refactor plugin selection logic in SearchImpl method

### DIFF
--- a/src/Asv.Drones.Gui/Shell/Pages/Settings/Plugins/Installed/PluginsInstalledViewModel.cs
+++ b/src/Asv.Drones.Gui/Shell/Pages/Settings/Plugins/Installed/PluginsInstalledViewModel.cs
@@ -65,7 +65,6 @@ public class PluginsInstalledViewModel : TreePageViewModel
 
     private void SearchImpl()
     {
-        _pluginSearchSource.Clear();
         _pluginSearchSource.AddOrUpdate(_manager.Installed);
     }
 


### PR DESCRIPTION
Updated the SearchImpl method in PluginsMarket to retain the previously selected plugin after a search update, by comparing plugin IDs. Also applied code style improvements for readability and robustness.

The Clear call on _pluginSearchSource in PluginsInstalled was unnecessary given that AddOrUpdate effectively manages the items.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208151005396126