### PR TITLE
fix: migrate device pages to OnDeviceInitialized observable

### DIFF
--- a/src/Asv.Drones/Shell/Pages/Device/FileBrowser/FileBrowserViewModel.cs
+++ b/src/Asv.Drones/Shell/Pages/Device/FileBrowser/FileBrowserViewModel.cs
@@ -277,6 +277,13 @@ public class FileBrowserViewModel
             .DisposeItWith(Disposable);
 
         InitCommands();
+
+        Target
+            .Where(w => w.HasValue)
+            .Select(w => w!.Value)
+            .ObserveOnUIThreadDispatcher()
+            .Subscribe(w => OnDeviceConnected(w.Device, w.WhenDisconnectedToken))
+            .DisposeItWith(Disposable);
     }
 
     #region Properties
@@ -1133,10 +1140,7 @@ public class FileBrowserViewModel
 
     #endregion
 
-    protected override void AfterDeviceInitialized(
-        IClientDevice device,
-        CancellationToken onDisconnectedToken
-    )
+    private void OnDeviceConnected(IClientDevice device, CancellationToken onDisconnectedToken)
     {
         Header = $"{RS.FileBrowserViewModel_Title}[{device.Id}]";
         Icon = DeviceIconMixin.GetIcon(device.Id) ?? PageIcon;

--- a/src/Asv.Drones/Shell/Pages/Device/MavParams/MavParamsPageView.axaml
+++ b/src/Asv.Drones/Shell/Pages/Device/MavParams/MavParamsPageView.axaml
@@ -67,6 +67,7 @@
                         Height="{CompiledBinding #SearchBox.Bounds.Height}"
                     >
                         <avalonia:MaterialIcon
+                            Classes="medium"
                             Kind="PinOff"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
@@ -80,6 +81,7 @@
                         Height="{CompiledBinding #SearchBox.Bounds.Height}"
                     >
                         <avalonia:MaterialIcon
+                            Classes="medium"
                             Kind="Sync"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
@@ -93,6 +95,7 @@
                         Height="{CompiledBinding #SearchBox.Bounds.Height}"
                     >
                         <avalonia:MaterialIcon
+                            Classes="medium"
                             Kind="Star"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"

--- a/src/Asv.Drones/Shell/Pages/Device/MavParams/MavParamsPageViewModel.cs
+++ b/src/Asv.Drones/Shell/Pages/Device/MavParams/MavParamsPageViewModel.cs
@@ -183,6 +183,13 @@ public class MavParamsPageViewModel
         );
 
         Events.Catch(InternalCatchEvent).DisposeItWith(Disposable);
+
+        Target
+            .Where(w => w.HasValue)
+            .Select(w => w!.Value)
+            .ObserveOnUIThreadDispatcher()
+            .Subscribe(w => OnDeviceConnected(w.Device, w.WhenDisconnectedToken))
+            .DisposeItWith(Disposable);
     }
 
     private Task UpdateImpl(string? query, IProgress<double> progress, CancellationToken cancel)
@@ -348,7 +355,7 @@ public class MavParamsPageViewModel
         }
     }
 
-    protected override void AfterDeviceInitialized(IClientDevice device, CancellationToken cancel)
+    private void OnDeviceConnected(IClientDevice device, CancellationToken cancel)
     {
         Header = $"{RS.MavParamsPageViewModel_Title}[{device.Id}]";
         _paramsClient = device.GetMicroservice<IParamsClientEx>();
@@ -372,10 +379,14 @@ public class MavParamsPageViewModel
     public INotifyCollectionChangedSynchronizedViewList<ParamItemViewModel>? AllParams
     {
         get;
-        private set;
+        private set => SetField(ref field, value);
     }
 
-    public IReadOnlyBindableReactiveProperty<int> Total { get; private set; }
+    public IReadOnlyBindableReactiveProperty<int> Total
+    {
+        get;
+        private set => SetField(ref field, value);
+    }
 
     public INotifyCollectionChangedSynchronizedViewList<ParamItemViewModel> ViewedParams { get; }
 

--- a/src/Asv.Drones/Shell/Pages/Device/Setup/SetupPageViewModel.cs
+++ b/src/Asv.Drones/Shell/Pages/Device/Setup/SetupPageViewModel.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Threading;
 using Asv.Avalonia;
 using Asv.Avalonia.IO;
+using Asv.Common;
 using Asv.Drones.Api;
 using Asv.IO;
 using Material.Icons;
 using Microsoft.Extensions.Logging;
+using R3;
 
 namespace Asv.Drones;
 
@@ -25,12 +26,16 @@ public class SetupPageViewModel : TreeDevicePageViewModel<ISetupPage, ISetupSubp
         : base(PageId, context, devices, container, loggerFactory, dialogService, ext)
     {
         Icon = PageIcon;
+
+        Target
+            .Where(w => w.HasValue)
+            .Select(w => w!.Value)
+            .ObserveOnUIThreadDispatcher()
+            .Subscribe(w => OnDeviceConnected(w.Device))
+            .DisposeItWith(Disposable);
     }
 
-    protected override void AfterDeviceInitialized(
-        IClientDevice device,
-        CancellationToken onDisconnectedToken
-    )
+    private void OnDeviceConnected(IClientDevice device)
     {
         Header = $"{RS.SetupPageViewModel_Title}[{device.Id}]";
         TreeHeader = RS.SetupPageViewModel_Title;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,9 +4,9 @@
     <ProductVersion>3.0.0-dev.0</ProductVersion>
     <TargetFramework>net10.0</TargetFramework>
     <ApiVersion>3.0.0</ApiVersion>
-    <AvaloniaVersion>12.0.3</AvaloniaVersion>
+    <AvaloniaVersion>12.0.4</AvaloniaVersion>
     <AvaloniaDataGridVersion>12.0.0</AvaloniaDataGridVersion>
-    <AsvAvaloniaVersion>3.0.0-dev.11</AsvAvaloniaVersion>
+    <AsvAvaloniaVersion>3.0.0-dev.18</AsvAvaloniaVersion>
     <AsvMavlinkVersion>4.3.0-dev.1</AsvMavlinkVersion>
     <AsvGnssVersion>2.2.0-dev.1</AsvGnssVersion>
     <ScottPlotVersion>5.1.58</ScottPlotVersion>


### PR DESCRIPTION
Subscribe to OnDeviceInitialized instead of the removed AfterDeviceInitialized override — fixes NRE/empty params when opening a page on an already-connected device. Also size MavParams toolbar icons and bump Asv.Avalonia.